### PR TITLE
docs: fix cross-module @refs breaking the Documentation build

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["souta shimozono"]
 
 [deps]

--- a/src/core/constructor.jl
+++ b/src/core/constructor.jl
@@ -5,8 +5,7 @@ Return the reciprocal-lattice basis associated with a real-space
 `basis` expressed as a vector of vectors. Uses
 ``B = 2\\pi (A^{-\\top})`` where the columns of ``A`` are the
 primitive real-space vectors. Provided for parity with the old
-public API; new code should prefer
-[`LatticeCore.reciprocal_lattice(lat)`](@ref LatticeCore.reciprocal_lattice).
+public API; new code should prefer `LatticeCore.reciprocal_lattice(lat)`.
 """
 function calc_reciprocal_vectors(basis::AbstractVector{<:AbstractVector})
     A = hcat(basis...)
@@ -60,7 +59,7 @@ end
 
 Normalise the user-facing `boundary` argument of
 [`build_lattice`](@ref) to a `LatticeBoundary{2}`. A single axis BC
-is broadcast to both axes with a [`NoModifier`](@ref); an explicit
+is broadcast to both axes with a `NoModifier`; an explicit
 `LatticeBoundary` is returned as-is.
 """
 _resolve_boundary(axis::AbstractAxisBC) = LatticeBoundary((axis, axis), NoModifier())
@@ -76,10 +75,9 @@ _resolve_boundary(boundary::LatticeBoundary) = boundary
 
 Construct a finite 2D lattice of topology `Topology` on an
 `Lx × Ly` sample. The `boundary` argument accepts either a single
-[`LatticeCore.AbstractAxisBC`](@ref LatticeCore.AbstractAxisBC)
-(broadcast to both axes) or an explicit
-[`LatticeCore.LatticeBoundary`](@ref LatticeCore.LatticeBoundary)
-for mixed-axis setups such as cylinders.
+`LatticeCore.AbstractAxisBC` (broadcast to both axes) or an
+explicit `LatticeCore.LatticeBoundary` for mixed-axis setups such
+as cylinders.
 
 # Examples
 

--- a/src/core/periodic_lattice_2d.jl
+++ b/src/core/periodic_lattice_2d.jl
@@ -2,8 +2,7 @@
     PeriodicLattice2D{Topo, T, B, I, L}
 
 Finite 2D periodic lattice built from a topology
-([`get_unit_cell`](@ref)) and a
-[`LatticeCore.LatticeBoundary`](@ref LatticeCore.LatticeBoundary).
+([`get_unit_cell`](@ref)) and a `LatticeCore.LatticeBoundary`.
 Subtype of `LatticeCore.AbstractLattice{2, T}`; every
 LatticeCore-side method (`num_sites`, `position`, `neighbors`,
 `boundary`, `size_trait`, `site_layout`, `reciprocal_lattice`, ...)


### PR DESCRIPTION
## Description

The Lattice2D `v0.2.2` merge broke the Documentation CI with four `Cannot resolve @ref` errors. This PR fixes them.

**This is not a registry-registration issue.** LatticeCore is resolved correctly by Pkg through Lattice2D's `[sources]` entry, and the build compiles fine. The failure is purely in how a handful of docstrings wrote cross-module `@ref` links that Documenter could not resolve.

Fixed: broken Documentation workflow on `main` and `v0.2.2`

## Type of Change

- [ ] ✨ Feature
- [x] 🐛 Bug Fix — Documentation build
- [ ] ⚡ Performance
- [ ] 📖 Documentation
- [ ] 🧰 Maintenance

## Root cause

A handful of docstrings in `src/core/constructor.jl` and `src/core/periodic_lattice_2d.jl` used fully-qualified cross-module references:

```
[`LatticeCore.LatticeBoundary`](@ref LatticeCore.LatticeBoundary)
[`LatticeCore.AbstractAxisBC`](@ref LatticeCore.AbstractAxisBC)
[`LatticeCore.reciprocal_lattice(lat)`](@ref LatticeCore.reciprocal_lattice)
[`NoModifier`](@ref)
```

Documenter's `@autodocs Modules = [Lattice2D]` picks these symbols up through the re-exports but cannot resolve the targets because `LatticeCore` is not in the `modules` list. The errors bubble up as hard `[:cross_references]` failures and terminate the build before any HTML is rendered.

## Fix

- **`src/core/constructor.jl`**
  - `calc_reciprocal_vectors` docstring: drop the `reciprocal_lattice` `@ref`, use a plain `LatticeCore.reciprocal_lattice(lat)` code span.
  - `build_lattice` docstring: replace `[`LatticeCore.AbstractAxisBC`](@ref ...)` and `[`LatticeCore.LatticeBoundary`](@ref ...)` with plain backtick spans.
  - `_resolve_boundary` docstring: replace `[`NoModifier`](@ref)` with a plain backtick span, since `NoModifier` is a re-exported symbol whose docstring lives in LatticeCore.
- **`src/core/periodic_lattice_2d.jl`**
  - `PeriodicLattice2D` docstring: drop the `LatticeBoundary` `@ref`.

Internal `@ref`s that point at Lattice2D-local symbols (`get_unit_cell`, `build_lattice`, `PeriodicLattice2D`) are kept — those resolve cleanly.

## Verification

Built `docs/make.jl` locally with `julia --project=docs/`; the `CrossReferences`, `CheckDocument`, and `RenderDocument` stages all pass. No `@ref` errors remain.

## Version

`Project.toml`: `0.2.2` → `0.2.3` (docs-only patch bump).

## Follow-up (out of scope)

A longer-term fix would be to add `LatticeCore` to `modules =` in `docs/make.jl`, which would let Lattice2D's docs legitimately reference LatticeCore docstrings inline. That is out of scope for this hotfix (it would also require deciding how much of LatticeCore's API reference should be mirrored into Lattice2D's site), and is tracked informally as a follow-up alongside the planned `plot_lattice` LatticeCore package extension.

## check list
- [x] test駆動をしたか — local Documenter build now passes