### PR TITLE
feat: multi-shell geometric neighbours (F1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["souta shimozono"]
 
 [deps]

--- a/src/core/lattice.jl
+++ b/src/core/lattice.jl
@@ -199,7 +199,7 @@ function _neighbors_by_shell(lat::Lattice{Topo,T}, i::Int, k::Int) where {Topo,T
     # site j from site i across all unwrapped (dx, dy, sub') candidates.
     dist_map = Dict{Int,T}()
 
-    for dy in -(Ly - 1):(Ly - 1), dx in -(Lx - 1):(Lx - 1), s in 1:nsub
+    for dy in (-(Ly - 1)):(Ly - 1), dx in (-(Lx - 1)):(Lx - 1), s in 1:nsub
         tx = cx + dx
         ty = cy + dy
         nx, ok_x = apply_axis_bc(bx, tx, Lx)

--- a/src/core/lattice.jl
+++ b/src/core/lattice.jl
@@ -144,16 +144,101 @@ function _connection_steps(lat::Lattice{Topo,T}, i::Int) where {Topo,T}
     return steps
 end
 
-function LatticeCore.neighbors(lat::Lattice, i::Int)
-    out = Int[]
-    seen = Set{Int}()
-    for (j, _, _) in _connection_steps(lat, i)
-        if j != i && !(j in seen)
-            push!(out, j)
-            push!(seen, j)
+"""
+    neighbors(lat::Lattice, i::Int) → Vector{Int}
+    neighbors(lat::Lattice, i::Int; shell::Int) → Vector{Int}
+
+Neighbour indices of site `i`.
+
+- Without the `shell` keyword, returns **all declared unit-cell
+  connections**. For most topologies this is the geometric NN; for
+  topologies whose unit cell mixes bond types at different distances
+  (e.g. [`ShastrySutherland`](@ref), which declares both square NN
+  and dimer J′ bonds), the returned set is the union.
+- With `shell=k` (k ≥ 1), returns the `k`-th **geometric** neighbour
+  shell, ranked by Euclidean distance. For `ShastrySutherland` this
+  separates the square NN (`shell=1`) from the dimer partner
+  (`shell=2`).
+
+The geometric search is bounded by the sample size — for PBC the
+minimum-image distance is used, for OBC only in-sample candidates
+are considered.
+"""
+function LatticeCore.neighbors(lat::Lattice, i::Int; shell::Union{Nothing,Int}=nothing)
+    if shell === nothing
+        out = Int[]
+        seen = Set{Int}()
+        for (j, _, _) in _connection_steps(lat, i)
+            if j != i && !(j in seen)
+                push!(out, j)
+                push!(seen, j)
+            end
+        end
+        return out
+    else
+        shell ≥ 1 || throw(ArgumentError("shell must be ≥ 1, got $shell"))
+        return _neighbors_by_shell(lat, i, shell)
+    end
+end
+
+# Compute geometric k-th shell neighbours by scanning a full
+# `(−Lx, Lx) × (−Ly, Ly)` window of unit-cell displacements, filtering
+# candidates through the axis BCs and ranking unique distances.
+function _neighbors_by_shell(lat::Lattice{Topo,T}, i::Int, k::Int) where {Topo,T}
+    Lx, Ly = _dims(lat)
+    nsub = num_sublattices(lat)
+    coord_i = lattice_coord(lat.indexing, (Lx, Ly), nsub, i)
+    cx, cy = coord_i.cell
+    si = coord_i.sublattice
+
+    bx, by = lat.boundary.axes
+    a1, a2 = _basis_sv(typeof(lat))
+    subs = _sub_offsets(typeof(lat))
+
+    # `dist_map[j]` is the minimum distance at which we've reached
+    # site j from site i across all unwrapped (dx, dy, sub') candidates.
+    dist_map = Dict{Int,T}()
+
+    for dy in -(Ly - 1):(Ly - 1), dx in -(Lx - 1):(Lx - 1), s in 1:nsub
+        tx = cx + dx
+        ty = cy + dy
+        nx, ok_x = apply_axis_bc(bx, tx, Lx)
+        ok_x || continue
+        ny, ok_y = apply_axis_bc(by, ty, Ly)
+        ok_y || continue
+        j = site_index(lat.indexing, (Lx, Ly), nsub, LatticeCoord{2}((nx, ny), s))
+        j == i && continue
+        d_vec = dx * a1 + dy * a2 + (subs[s] - subs[si])
+        d = norm(d_vec)
+        cur = get(dist_map, j, typemax(T))
+        if d < cur
+            dist_map[j] = d
         end
     end
-    return out
+
+    isempty(dist_map) && return Int[]
+
+    # Group unique distances with a tolerance (float noise from basis
+    # matrix multiplication can jitter the last few ulps).
+    sorted_d = sort(collect(values(dist_map)))
+    shells = T[sorted_d[1]]
+    for d in sorted_d
+        ref = shells[end]
+        if d - ref > 10 * eps(T) * max(one(T), ref)
+            push!(shells, d)
+        end
+    end
+
+    k > length(shells) && return Int[]
+    target = shells[k]
+    tol = 10 * eps(T) * max(one(T), target)
+    result = Int[]
+    for (j, d) in dist_map
+        if abs(d - target) ≤ tol
+            push!(result, j)
+        end
+    end
+    return sort!(result)
 end
 
 function LatticeCore.neighbor_bonds(lat::Lattice{Topo,T}, i::Int) where {Topo,T}

--- a/test/core/test_shell_neighbors.jl
+++ b/test/core/test_shell_neighbors.jl
@@ -80,9 +80,7 @@
         counts = Dict{Symbol,Int}()
         for indexing in (RowMajor(), ColMajor(), Snake())
             lat = build_lattice(Square, 4, 4; indexing=indexing)
-            counts[Symbol(typeof(indexing).name.name)] = length(
-                neighbors(lat, 1; shell=1)
-            )
+            counts[Symbol(typeof(indexing).name.name)] = length(neighbors(lat, 1; shell=1))
         end
         @test length(unique(values(counts))) == 1
     end

--- a/test/core/test_shell_neighbors.jl
+++ b/test/core/test_shell_neighbors.jl
@@ -1,0 +1,89 @@
+@testset "multi-shell neighbours" begin
+    @testset "Square PBC: shells are axial / diagonal / 2-axial" begin
+        lat = build_lattice(Square, 6, 6)
+        # Shell 1: 4 axial neighbours at distance 1
+        @test length(neighbors(lat, 1; shell=1)) == 4
+        # Shell 2: 4 diagonal neighbours at distance √2
+        @test length(neighbors(lat, 1; shell=2)) == 4
+        # Shell 3: 4 next-axial at distance 2
+        @test length(neighbors(lat, 1; shell=3)) == 4
+
+        # Declared = shell=1 for Square (NN only)
+        @test sort(neighbors(lat, 1)) == sort(neighbors(lat, 1; shell=1))
+    end
+
+    @testset "Triangular PBC: six NN / six 2nd-NN / six 3rd-NN" begin
+        lat = build_lattice(Triangular, 6, 6)
+        @test length(neighbors(lat, 1; shell=1)) == 6
+        @test length(neighbors(lat, 1; shell=2)) == 6
+        @test length(neighbors(lat, 1; shell=3)) == 6
+    end
+
+    @testset "Honeycomb PBC: 3 / 6 / 3 interleaving" begin
+        lat = build_lattice(Honeycomb, 4, 4)
+        # From an A site: NN are the 3 B partners
+        @test length(neighbors(lat, 1; shell=1)) == 3
+        # 2nd shell: 6 same-sublattice (triangular) neighbours
+        @test length(neighbors(lat, 1; shell=2)) == 6
+        # 3rd shell: 3 more B partners at the next Honeycomb distance
+        @test length(neighbors(lat, 1; shell=3)) == 3
+    end
+
+    @testset "Shastry–Sutherland: declared ≠ geometric shell 1" begin
+        lat = build_lattice(ShastrySutherland, 4, 4)
+        # Declared: 4 square NN + 1 dimer partner per site
+        @test length(neighbors(lat, 1)) == 5
+        # Geometric shell 1: only the 4 square NN (distance 1)
+        @test length(neighbors(lat, 1; shell=1)) == 4
+        # Geometric shell 2: includes the dimer partner and any other
+        # sites at the same √2 distance — the dimer partner must be
+        # among the returned indices.
+        shell2 = neighbors(lat, 1; shell=2)
+        declared = neighbors(lat, 1)
+        dimer_partner = setdiff(declared, neighbors(lat, 1; shell=1))
+        @test length(dimer_partner) == 1
+        @test dimer_partner[1] in shell2
+    end
+
+    @testset "OBC restricts the shell count for corner sites" begin
+        lat = build_lattice(Square, 4, 4; boundary=OpenAxis())
+        # Site 1 is the (1, 1) corner: 2 axial neighbours, 1 diagonal.
+        @test length(neighbors(lat, 1; shell=1)) == 2
+        @test length(neighbors(lat, 1; shell=2)) == 1
+    end
+
+    @testset "shell must be ≥ 1" begin
+        lat = build_lattice(Square, 3, 3)
+        @test_throws ArgumentError neighbors(lat, 1; shell=0)
+        @test_throws ArgumentError neighbors(lat, 1; shell=-1)
+    end
+
+    @testset "over-deep shell returns empty" begin
+        lat = build_lattice(Square, 3, 3)
+        # Well beyond any reachable distance on a 3×3 lattice.
+        @test isempty(neighbors(lat, 1; shell=100))
+    end
+
+    @testset "shells are mutually disjoint" begin
+        lat = build_lattice(Triangular, 6, 6)
+        s1 = Set(neighbors(lat, 1; shell=1))
+        s2 = Set(neighbors(lat, 1; shell=2))
+        s3 = Set(neighbors(lat, 1; shell=3))
+        @test isempty(intersect(s1, s2))
+        @test isempty(intersect(s1, s3))
+        @test isempty(intersect(s2, s3))
+    end
+
+    @testset "indexing-invariant: shell count is a geometric property" begin
+        # The set of shell-1 distances from a PBC Square site is the
+        # same regardless of RowMajor / ColMajor / Snake indexing.
+        counts = Dict{Symbol,Int}()
+        for indexing in (RowMajor(), ColMajor(), Snake())
+            lat = build_lattice(Square, 4, 4; indexing=indexing)
+            counts[Symbol(typeof(indexing).name.name)] = length(
+                neighbors(lat, 1; shell=1)
+            )
+        end
+        @test length(unique(values(counts))) == 1
+    end
+end


### PR DESCRIPTION
## Summary

Implements **requirement F1 (unified shell interface)** from `dev/0_lattice-refactor/03_requirements/README.md`. Adds a `shell` keyword to `Lattice2D.neighbors` so downstream code can query geometric neighbour shells in a topology-agnostic way:

```julia
lat = build_lattice(Square, 6, 6)
neighbors(lat, i)                  # declared NN (unchanged)
neighbors(lat, i; shell=1)         # 1st geometric shell
neighbors(lat, i; shell=2)         # 2nd (diagonal on Square)
neighbors(lat, i; shell=3)         # 3rd (next-axial on Square)
```

### Semantics

- **Without `shell`**: returns the set of **declared unit-cell connections** — same as before. Backwards compatible.
- **With `shell=k` (k ≥ 1)**: returns the **k-th geometric shell**, ranked by Euclidean distance.

These two views agree for most shipped topologies (Square / Triangular / Honeycomb / Kagome / Lieb / Dice / UnionJack), but **intentionally diverge on `ShastrySutherland`**, whose unit cell declares both the square NN (distance 1) and the dimer J′ bonds (distance √2):

| call | returns | count |
| --- | --- | --- |
| `neighbors(ss, i)` | 4 square NN + 1 dimer partner | 5 |
| `neighbors(ss, i; shell=1)` | square NN only | 4 |
| `neighbors(ss, i; shell=2)` | sites at distance √2 incl. dimer partner | 4 |

### Implementation

`_neighbors_by_shell` in [`src/core/lattice.jl`](src/core/lattice.jl) walks a full `(−Lx+1..Lx−1) × (−Ly+1..Ly−1)` box of unit-cell displacements, filters each candidate through the axis BCs, collects the **minimum-image** distance per reachable site, groups distances with a float tolerance, and returns the k-th unique group. PBC / OBC / cylinder / twisted all fall out of the BC pipeline for free.

This is lazy (no precomputation, no caching) consistent with the rest of the new `Lattice`.

## Test plan

Added [`test/core/test_shell_neighbors.jl`](test/core/test_shell_neighbors.jl) — 23 new assertions:

- Square PBC: shells 1/2/3 = 4/4/4 at distances 1/√2/2.
- Triangular PBC: shells 1/2/3 = 6/6/6.
- Honeycomb PBC: shells 1/2/3 = 3/6/3 (alternating sublattice).
- ShastrySutherland: declared=5, shell=1=4, shell=2 contains the dimer partner.
- Square OBC: corner site has 2 NN, 1 diagonal.
- `shell=0` / `shell=-1` throw `ArgumentError`.
- `shell=100` on a 3×3 returns `[]`.
- Shells 1/2/3 are mutually disjoint (triangular).
- RowMajor / ColMajor / Snake indexing give the same shell counts (geometric invariant).

- [x] `Pkg.test()` — **962 / 962 pass** (up from 939).

## Type of Change

- [x] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)