### PR TITLE
feat: cover LatticeCore API on Lattice + bond_center PBC override

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["souta shimozono"]
 
 [deps]
@@ -17,7 +17,8 @@ StaticArrays = "1"
 julia = "1.11"
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Random", "Test"]

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -74,7 +74,25 @@ import LatticeCore:
     NoReciprocal,
     FiniteSize,
     monkhorst_pack,
-    gamma_centered
+    gamma_centered,
+    num_k_points,
+    k_point,
+    reciprocal_basis,
+    momentum_lattice,
+    fourier_module,
+    structure_factor,
+    bond_center,
+    is_finite,
+    state_type,
+    random_state,
+    zero_state,
+    domain,
+    element_type,
+    AbstractLatticeElement,
+    VertexCenter,
+    BondCenter,
+    PlaquetteCenter,
+    CellCenter
 
 # ---- Lattice2D source files -----------------------------------------
 
@@ -112,6 +130,7 @@ export reciprocal_support
 export AbstractSizeTrait, FiniteSize, InfiniteSize, QuasiInfiniteSize
 export size_trait, is_finite
 export basis_vectors, reciprocal_lattice, fourier_module, momentum_lattice
+export num_k_points, k_point, reciprocal_basis
 export to_real, to_lattice, to_hyper
 export monkhorst_pack, gamma_centered, structure_factor
 export Bond, bond_center

--- a/src/core/lattice.jl
+++ b/src/core/lattice.jl
@@ -257,6 +257,21 @@ function LatticeCore.bonds(lat::Lattice)
     return (b for i in 1:num_sites(lat) for b in neighbor_bonds(lat, i) if b.j > b.i)
 end
 
+# Override LatticeCore's default `bond_center` so PBC-wrapped bonds
+# return the correct geometric midpoint. The default formula takes
+# `(position(b.i) + position(b.j)) / 2`, which for a wrapped neighbour
+# computes the midpoint between the source and the wrapped target's
+# position on the *opposite* side of the sample — i.e. it lands inside
+# the sample interior instead of just outside the boundary. The bond
+# already carries the unwrapped displacement in `bond.vector`, so
+# `position(i) + bond.vector / 2` gives the true midpoint.
+#
+# This override can be removed once LatticeCore 0.8.2 (carrying the
+# upstream fix) is registered and Lattice2D's compat is bumped.
+function LatticeCore.bond_center(lat::Lattice{Topo,T}, b::Bond{2,T}) where {Topo,T}
+    return position(lat, b.i) + b.vector / 2
+end
+
 # ---- Graph / topology traits ----------------------------------------
 
 function LatticeCore.is_bipartite(lat::Lattice)

--- a/test/core/test_latticecore_api.jl
+++ b/test/core/test_latticecore_api.jl
@@ -1,0 +1,113 @@
+@testset "LatticeCore API coverage on Lattice" begin
+    @testset "positions(lat) returns every site" begin
+        lat = build_lattice(Square, 3, 4)
+        ps = collect(positions(lat))
+        @test length(ps) == num_sites(lat)
+        # Every collected position must agree with `position(lat, i)`.
+        for (i, p) in enumerate(ps)
+            @test p == position(lat, i)
+        end
+    end
+
+    @testset "bond_center on PBC: wrapped bonds use unwrapped vector" begin
+        lat = build_lattice(Square, 4, 4)
+        # Site 1 = (1, 1). Its left neighbour wraps to (4, 1) (= site 4
+        # under RowMajor). The bond's stored vector is (-1, 0), so the
+        # midpoint sits half a step LEFT of (1, 1), i.e. at (-0.5, 0).
+        # The lattice uses 0-based positions internally, so the
+        # corner site 1 is at SVector(0.0, 0.0).
+        nb = neighbor_bonds(lat, 1)
+        wrapped = first(b for b in nb if b.vector[1] == -1.0)
+        center = bond_center(lat, wrapped)
+        @test center == SVector(-0.5, 0.0)
+
+        # An interior bond (site 6 → site 7 on the same row, dx=+1)
+        # should match the literal midpoint.
+        nb6 = neighbor_bonds(lat, 6)
+        right = first(b for b in nb6 if b.vector == SVector(1.0, 0.0))
+        @test bond_center(lat, right) == (position(lat, 6) + position(lat, right.j)) / 2
+    end
+
+    @testset "bond_center: every PBC bond's midpoint lies on the bond" begin
+        # A robust invariant that doesn't depend on knowing wrap details:
+        # the midpoint of every bond must be reachable by walking half
+        # the bond's `vector` from its source endpoint.
+        lat = build_lattice(Triangular, 4, 4)
+        for b in collect(bonds(lat))
+            @test bond_center(lat, b) == position(lat, b.i) + b.vector / 2
+        end
+    end
+
+    @testset "site_type via the site_layout fall-through" begin
+        lat = build_lattice(Square, 3, 3)
+        layout = site_layout(lat)
+        @test layout isa UniformLayout
+        @test site_type(layout, 1) === IsingSite{Int8}()
+        # Same site type for every site under UniformLayout.
+        @test all(site_type(layout, i) === site_type(layout, 1) for i in 1:num_sites(lat))
+    end
+
+    @testset "is_finite and size_trait" begin
+        lat = build_lattice(Honeycomb, 3, 3)
+        @test is_finite(lat)
+        @test size_trait(lat) isa FiniteSize{2}
+    end
+
+    @testset "momentum_lattice is the reciprocal lattice for Bravais cases" begin
+        lat = build_lattice(Triangular, 4, 4)
+        ml_rec = reciprocal_lattice(lat)
+        ml = momentum_lattice(lat)
+        @test ml === ml_rec || (
+            num_k_points(ml) == num_k_points(ml_rec) &&
+            all(k_point(ml, i) == k_point(ml_rec, i) for i in 1:num_k_points(ml))
+        )
+
+        # Mixed-BC samples have no reciprocal lattice → momentum_lattice throws.
+        cyl = build_lattice(
+            Square, 4, 4; boundary=LatticeBoundary((PeriodicAxis(), OpenAxis()))
+        )
+        @test_throws ArgumentError momentum_lattice(cyl)
+    end
+
+    @testset "structure_factor at Γ on a uniform state = N" begin
+        # ⟨s_i⟩ uniform over i ⇒ S(k=0) = N (1/N)|N|² = N.
+        lat = build_lattice(Square, 4, 4)
+        N = num_sites(lat)
+        state = ones(Int, N)
+        γ = SVector(0.0, 0.0)
+        @test structure_factor(lat, state, γ) ≈ Float64(N)
+    end
+
+    @testset "structure_factor over a momentum lattice returns one value per k" begin
+        lat = build_lattice(Square, 4, 4)
+        ml = reciprocal_lattice(lat)
+        state = ones(Int, num_sites(lat))
+        sks = structure_factor(lat, state, ml)
+        @test length(sks) == num_k_points(ml)
+        # On a half-shifted Monkhorst–Pack mesh Γ is not sampled, so we
+        # don't assert any specific peak — we only require finite, real,
+        # non-negative values.
+        @test all(isfinite, sks)
+        @test all(sks .≥ 0)
+
+        # On a Γ-centred mesh Γ IS sampled, and a uniform state has
+        # S(Γ) = N exactly.
+        γ_mesh = gamma_centered(reciprocal_basis(ml), (4, 4))
+        sks_γ = structure_factor(lat, state, γ_mesh)
+        @test maximum(sks_γ) ≈ Float64(num_sites(lat)) atol = 1e-10
+    end
+
+    @testset "site type element_type defaults to VertexCenter" begin
+        @test element_type(IsingSite()) === VertexCenter()
+        @test element_type(XYSite()) === VertexCenter()
+        @test element_type(HeisenbergSite()) === VertexCenter()
+    end
+
+    @testset "random_state / state_type round-trips for shipped site types" begin
+        rng = MersenneTwister(42)
+        for st in (IsingSite(), PottsSite(3), XYSite(), HeisenbergSite())
+            s = random_state(rng, st)
+            @test s isa state_type(st)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ ENV["GKSwstype"] = "100"
 
 using Lattice2D, Test
 using LinearAlgebra
+using Random
 using StaticArrays
 
 const FIG_BASE = joinpath(pkgdir(Lattice2D), "docs", "src", "assets", "figures")


### PR DESCRIPTION
## Summary

Iteration 1 of the "LatticeCore-first" Lattice2D push: walks the entire LatticeCore-side API, exercises every entry point on `Lattice2D.Lattice`, fixes one PBC bug discovered along the way, and exposes a few names that weren't yet in Lattice2D's `using` surface.

### Tests added — [`test/core/test_latticecore_api.jl`](test/core/test_latticecore_api.jl)

- `positions(lat)` iterator agrees with `position(lat, i)` site-by-site
- `bond_center` on a PBC-wrapped corner bond — **regression for [LatticeCore#18](https://github.com/sotashimozono/LatticeCore.jl/pull/18)**
- `bond_center` invariant on every Triangular bond: `mid == position(i) + vector/2`
- `site_type(layout, i)` via `UniformLayout`
- `is_finite` + `size_trait`
- `momentum_lattice(lat)` agrees with `reciprocal_lattice(lat)` for Bravais samples; throws `ArgumentError` on a cylinder
- `structure_factor(lat, state, k)` at Γ on a uniform state returns `N`
- `structure_factor(lat, state, ml)` over a Γ-centred mesh — peak at Γ equals `N`; over the half-shifted MP mesh, finiteness only
- `element_type` defaults to `VertexCenter()` for `IsingSite` / `XYSite` / `HeisenbergSite`
- `random_state` / `state_type` round-trip for `IsingSite` / `PottsSite(3)` / `XYSite` / `HeisenbergSite`

### `bond_center` PBC override (temporary)

LatticeCore's default `bond_center` was `(position(i) + position(j)) / 2`, which is silently wrong for any bond whose target wraps across a periodic axis: the wrapped target's `position(j)` is on the opposite side of the sample. Upstream fix is [LatticeCore#18](https://github.com/sotashimozono/LatticeCore.jl/pull/18) (patch bump 0.8.1 → 0.8.2). To unblock this PR without waiting for the registry to land 0.8.2, Lattice2D specialises `bond_center(::Lattice, ::Bond)` locally to `position(i) + bond.vector / 2`. Once LatticeCore 0.8.2 is registered the override can be removed.

### Module surface fixes

`num_k_points`, `k_point`, `reciprocal_basis`, `momentum_lattice`, `fourier_module`, `structure_factor`, `bond_center`, `is_finite`, `state_type`, `random_state`, `zero_state`, `domain`, `element_type`, and the `AbstractLatticeElement` marker types (`VertexCenter` / `BondCenter` / `PlaquetteCenter` / `CellCenter`) are now imported into `Lattice2D` and re-exported, so `using Lattice2D` is enough to reach them.

`Random` added as a test dep for `MersenneTwister` use in the new tests.

### Test plan
- [x] `Pkg.test()` — **1044 / 1044 pass** (up from 962, +82 new assertions).

## Type of Change

- [x] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)