### PR TITLE
feat: plaquettes via PlaquetteRule (Square/Triangular/Honeycomb/Kagome)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["souta shimozono"]
 
 [deps]
@@ -9,8 +9,14 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+# Temporary — points at LatticeCore.jl#20 (feat/plaquette-and-incidence).
+# Remove once LatticeCore 0.8.4 is registered in the General registry;
+# [compat] alone will pick it up thereafter.
+[sources]
+LatticeCore = {url = "https://github.com/sotashimozono/LatticeCore.jl.git", rev = "ca46deb5c6120f73f653c46a141ff242fe49b80d"}
+
 [compat]
-LatticeCore = "0.8"
+LatticeCore = "0.8.4"
 LinearAlgebra = "1"
 Plots = "1"
 StaticArrays = "1"

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -92,7 +92,18 @@ import LatticeCore:
     VertexCenter,
     BondCenter,
     PlaquetteCenter,
-    CellCenter
+    CellCenter,
+    num_elements,
+    elements,
+    element_position,
+    element_positions,
+    element_neighbors,
+    incident,
+    PlaquetteRule,
+    Plaquette,
+    plaquettes,
+    neighbor_plaquettes,
+    plaquette_center
 
 # ---- Lattice2D source files -----------------------------------------
 
@@ -137,6 +148,9 @@ export Bond, bond_center
 export apply_axis_bc, axis_phase, bond_weight
 export AbstractLatticeElement, VertexCenter, BondCenter, PlaquetteCenter, CellCenter
 export element_type, state_type, random_state, zero_state, domain
+export num_elements, elements, element_position, element_positions
+export element_neighbors, incident
+export PlaquetteRule, Plaquette, plaquettes, neighbor_plaquettes, plaquette_center
 export materialize, require_finite
 
 end # module Lattice2D

--- a/src/core/lattice.jl
+++ b/src/core/lattice.jl
@@ -257,19 +257,97 @@ function LatticeCore.bonds(lat::Lattice)
     return (b for i in 1:num_sites(lat) for b in neighbor_bonds(lat, i) if b.j > b.i)
 end
 
-# Override LatticeCore's default `bond_center` so PBC-wrapped bonds
-# return the correct geometric midpoint. The default formula takes
-# `(position(b.i) + position(b.j)) / 2`, which for a wrapped neighbour
-# computes the midpoint between the source and the wrapped target's
-# position on the *opposite* side of the sample — i.e. it lands inside
-# the sample interior instead of just outside the boundary. The bond
-# already carries the unwrapped displacement in `bond.vector`, so
-# `position(i) + bond.vector / 2` gives the true midpoint.
+# ---- Plaquette enumeration ------------------------------------------
 #
-# This override can be removed once LatticeCore 0.8.2 (carrying the
-# upstream fix) is registered and Lattice2D's compat is bumped.
-function LatticeCore.bond_center(lat::Lattice{Topo,T}, b::Bond{2,T}) where {Topo,T}
-    return position(lat, b.i) + b.vector / 2
+# Walks `(cell_x, cell_y, kind)` for every PlaquetteRule declared on
+# the topology, applies per-axis BCs to each corner, drops any
+# plaquette whose corners aren't all valid, and materialises the
+# result as a `Plaquette{2, T}` with its boundary vertex indices,
+# centroid and type tag.
+
+function LatticeCore.plaquettes(lat::Lattice{Topo,T}) where {Topo,T}
+    return _materialise_plaquettes(lat)
+end
+
+function _materialise_plaquettes(lat::Lattice{Topo,T}) where {Topo,T}
+    Lx, Ly = _dims(lat)
+    nsub = num_sublattices(lat)
+    uc = get_unit_cell(Topo)
+    bx, by = lat.boundary.axes
+    a1, a2 = _basis_sv(typeof(lat))
+    subs = _sub_offsets(typeof(lat))
+
+    out = Plaquette{2,T}[]
+    isempty(uc.plaquettes) && return out
+
+    for cy in 1:Ly, cx in 1:Lx
+        for rule in uc.plaquettes
+            vertices = Int[]
+            positions_acc = SVector{2,T}[]
+            valid = true
+            for (s, dx, dy) in rule.corners
+                tx, ty = cx + dx, cy + dy
+                nx, ok_x = apply_axis_bc(bx, tx, Lx)
+                if !ok_x
+                    valid = false
+                    break
+                end
+                ny, ok_y = apply_axis_bc(by, ty, Ly)
+                if !ok_y
+                    valid = false
+                    break
+                end
+                j = site_index(
+                    lat.indexing, (Lx, Ly), nsub,
+                    LatticeCoord{2}((nx, ny), s),
+                )
+                push!(vertices, j)
+                # Centroid uses the **unwrapped** corner position
+                # (relative to the anchor cell) so the centre of a
+                # PBC-wrapped plaquette sits just outside the sample
+                # edge instead of inside its interior — same rule
+                # `bond_center` uses.
+                anchor = (cx - 1) * a1 + (cy - 1) * a2
+                corner_pos = anchor + dx * a1 + dy * a2 + subs[s]
+                push!(positions_acc, corner_pos)
+            end
+            if valid
+                center = sum(positions_acc) / length(positions_acc)
+                push!(out, Plaquette{2,T}(vertices, center, rule.type))
+            end
+        end
+    end
+    return out
+end
+
+# Override `num_elements(::PlaquetteCenter)` so we never materialise
+# the whole list just to count — O(Lx*Ly) scan that skips rejected
+# corners by BC.
+function LatticeCore.num_elements(lat::Lattice{Topo}, ::PlaquetteCenter) where {Topo}
+    Lx, Ly = _dims(lat)
+    uc = get_unit_cell(Topo)
+    isempty(uc.plaquettes) && return 0
+    bx, by = lat.boundary.axes
+    count = 0
+    for cy in 1:Ly, cx in 1:Lx
+        for rule in uc.plaquettes
+            all_valid = true
+            for (_, dx, dy) in rule.corners
+                _, ok_x = apply_axis_bc(bx, cx + dx, Lx)
+                if !ok_x
+                    all_valid = false
+                    break
+                end
+                _, ok_y = apply_axis_bc(by, cy + dy, Ly)
+                if !ok_y
+                    all_valid = false
+                    break
+                end
+            end
+            all_valid && (count += 1)
+        end
+    end
+    return count
 end
 
 # ---- Graph / topology traits ----------------------------------------

--- a/src/core/lattice.jl
+++ b/src/core/lattice.jl
@@ -297,10 +297,7 @@ function _materialise_plaquettes(lat::Lattice{Topo,T}) where {Topo,T}
                     valid = false
                     break
                 end
-                j = site_index(
-                    lat.indexing, (Lx, Ly), nsub,
-                    LatticeCoord{2}((nx, ny), s),
-                )
+                j = site_index(lat.indexing, (Lx, Ly), nsub, LatticeCoord{2}((nx, ny), s))
                 push!(vertices, j)
                 # Centroid uses the **unwrapped** corner position
                 # (relative to the anchor cell) so the centre of a

--- a/src/core/topology.jl
+++ b/src/core/topology.jl
@@ -55,6 +55,10 @@ with an arbitrary basis. Contains
   geometric sublattice inside the unit cell
 - `connections::Vector{Connection}` — the full list of
   intra- and inter-cell connection rules for this topology
+- `plaquettes::Vector{LatticeCore.PlaquetteRule}` — declarative list
+  of plaquette rules (one per plaquette **kind**) anchored at the
+  reference cell. Empty for topologies that haven't been wired up to
+  the plaquette API yet.
 
 Produced by [`get_unit_cell`](@ref) on an `AbstractTopology`
 singleton.
@@ -63,6 +67,18 @@ struct UnitCell{D,T}
     basis::Vector{Vector{T}}
     sublattice_positions::Vector{Vector{T}}
     connections::Vector{Connection}
+    plaquettes::Vector{PlaquetteRule}
+end
+
+# Back-compat 3-arg constructor — legacy unit cells without any
+# declared plaquettes still work, they just contribute 0 plaquettes
+# to their lattice.
+function UnitCell{D,T}(
+    basis::Vector{Vector{T}},
+    sublattice_positions::Vector{Vector{T}},
+    connections::Vector{Connection},
+) where {D,T}
+    return UnitCell{D,T}(basis, sublattice_positions, connections, PlaquetteRule[])
 end
 
 """

--- a/src/core/unitcells.jl
+++ b/src/core/unitcells.jl
@@ -10,7 +10,12 @@ function get_unit_cell(::Type{Square})
     a1 = [1.0, 0.0]
     a2 = [0.0, 1.0]
     conns = [Connection(1, 1, 1, 0, 1), Connection(1, 1, 0, 1, 2)]
-    return UnitCell{2,Float64}([a1, a2], [[0.0, 0.0]], conns)
+    # Unit square with corners at (0,0), (1,0), (1,1), (0,1), walked CCW.
+    plaqs = [PlaquetteRule(
+        [(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)],
+        :square,
+    )]
+    return UnitCell{2,Float64}([a1, a2], [[0.0, 0.0]], conns, plaqs)
 end
 
 """
@@ -29,7 +34,14 @@ function get_unit_cell(::Type{Triangular})
         Connection(1, 1, 0, 1, 2),    # up (a2)
         Connection(1, 1, -1, 1, 3),   # upper-left (a2 − a1)
     ]
-    return UnitCell{2,Float64}([a1, a2], [[0.0, 0.0]], conns)
+    # Two triangles per unit cell:
+    #   up-triangle   : (0,0), (1,0), (0,1)       — points up-right
+    #   down-triangle : (1,0), (1,1), (0,1)       — points down-left
+    plaqs = [
+        PlaquetteRule([(1, 0, 0), (1, 1, 0), (1, 0, 1)], :up_triangle),
+        PlaquetteRule([(1, 1, 0), (1, 1, 1), (1, 0, 1)], :down_triangle),
+    ]
+    return UnitCell{2,Float64}([a1, a2], [[0.0, 0.0]], conns, plaqs)
 end
 
 """
@@ -50,7 +62,20 @@ function get_unit_cell(::Type{Honeycomb})
         Connection(1, 2, 1, -1, 2),    # A → B (upper-left cell)
         Connection(1, 2, 0, -1, 3),    # A → B (upper cell)
     ]
-    return UnitCell{2,Float64}([a1, a2], [d_A, d_B], conns)
+    # Hexagon anchored at A(0,0), walking CCW. The 6 corners are 3 A
+    # and 3 B sites in the cells (0,0), (1,-1), (1,0), (1,0), (0,1),
+    # (0,0). Verified geometrically: every edge has length 1 and the
+    # centroid lands at (sqrt(3)/2, 0.5).
+    plaqs = [PlaquetteRule(
+        [(1, 0, 0),     # A(0,0)
+         (2, 1, -1),    # B(1,-1)
+         (1, 1, 0),     # A(1,0)
+         (2, 1, 0),     # B(1,0)
+         (1, 0, 1),     # A(0,1)
+         (2, 0, 0)],    # B(0,0)
+        :hexagon,
+    )]
+    return UnitCell{2,Float64}([a1, a2], [d_A, d_B], conns, plaqs)
 end
 
 """
@@ -77,7 +102,15 @@ function get_unit_cell(::Type{Kagome})
         Connection(3, 1, 0, 1, 1),     # C → next A (up)
         Connection(2, 3, 1, -1, 1),    # B → next C (down-right)
     ]
-    return UnitCell{2,Float64}([a1, a2], [d_A, d_B, d_C], conns)
+    # The up-triangle is the intra-cell triangle A-B-C. The
+    # down-triangle lives between three neighbouring cells: B(0,0),
+    # A(1,0), C(1,-1). Hexagonal plaquettes exist in Kagome too but
+    # are left to a follow-up PR.
+    plaqs = [
+        PlaquetteRule([(1, 0, 0), (2, 0, 0), (3, 0, 0)], :up_triangle),
+        PlaquetteRule([(2, 0, 0), (1, 1, 0), (3, 1, -1)], :down_triangle),
+    ]
+    return UnitCell{2,Float64}([a1, a2], [d_A, d_B, d_C], conns, plaqs)
 end
 
 """

--- a/src/core/unitcells.jl
+++ b/src/core/unitcells.jl
@@ -11,10 +11,7 @@ function get_unit_cell(::Type{Square})
     a2 = [0.0, 1.0]
     conns = [Connection(1, 1, 1, 0, 1), Connection(1, 1, 0, 1, 2)]
     # Unit square with corners at (0,0), (1,0), (1,1), (0,1), walked CCW.
-    plaqs = [PlaquetteRule(
-        [(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)],
-        :square,
-    )]
+    plaqs = [PlaquetteRule([(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)], :square)]
     return UnitCell{2,Float64}([a1, a2], [[0.0, 0.0]], conns, plaqs)
 end
 
@@ -66,15 +63,19 @@ function get_unit_cell(::Type{Honeycomb})
     # and 3 B sites in the cells (0,0), (1,-1), (1,0), (1,0), (0,1),
     # (0,0). Verified geometrically: every edge has length 1 and the
     # centroid lands at (sqrt(3)/2, 0.5).
-    plaqs = [PlaquetteRule(
-        [(1, 0, 0),     # A(0,0)
-         (2, 1, -1),    # B(1,-1)
-         (1, 1, 0),     # A(1,0)
-         (2, 1, 0),     # B(1,0)
-         (1, 0, 1),     # A(0,1)
-         (2, 0, 0)],    # B(0,0)
-        :hexagon,
-    )]
+    plaqs = [
+        PlaquetteRule(
+            [
+                (1, 0, 0),     # A(0,0)
+                (2, 1, -1),    # B(1,-1)
+                (1, 1, 0),     # A(1,0)
+                (2, 1, 0),     # B(1,0)
+                (1, 0, 1),     # A(0,1)
+                (2, 0, 0),
+            ],    # B(0,0)
+            :hexagon,
+        ),
+    ]
     return UnitCell{2,Float64}([a1, a2], [d_A, d_B], conns, plaqs)
 end
 

--- a/test/core/test_plaquettes.jl
+++ b/test/core/test_plaquettes.jl
@@ -1,0 +1,126 @@
+@testset "plaquette enumeration on Lattice" begin
+    @testset "Square: 1 plaquette per unit cell under PBC" begin
+        for (Lx, Ly) in ((3, 3), (4, 4), (5, 3))
+            lat = build_lattice(Square, Lx, Ly)
+            @test num_elements(lat, PlaquetteCenter()) == Lx * Ly
+            ps = collect(plaquettes(lat))
+            @test length(ps) == Lx * Ly
+            @test all(p.type === :square for p in ps)
+            @test all(length(p.vertices) == 4 for p in ps)
+        end
+    end
+
+    @testset "Square: centroid is the cell + (0.5, 0.5)" begin
+        lat = build_lattice(Square, 4, 4)
+        ps = collect(plaquettes(lat))
+        # The plaquette anchored at cell (1, 1) has centroid (0.5, 0.5).
+        p1 = first(p for p in ps if p.center ≈ SVector(0.5, 0.5))
+        @test p1.type === :square
+        @test length(p1.vertices) == 4
+    end
+
+    @testset "Triangular: 2 plaquettes per unit cell, unit edges" begin
+        lat = build_lattice(Triangular, 6, 6)
+        @test num_elements(lat, PlaquetteCenter()) == 2 * 6 * 6
+        ps = collect(plaquettes(lat))
+        @test count(p -> p.type === :up_triangle, ps) == 6 * 6
+        @test count(p -> p.type === :down_triangle, ps) == 6 * 6
+
+        # Every interior up-triangle has unit edges.
+        center = SVector(3.0, 3.0)
+        up = first(
+            p for p in ps if p.type === :up_triangle && norm(p.center - center) < 1.5
+        )
+        @test length(up.vertices) == 3
+        for i in 1:3
+            a = position(lat, up.vertices[i])
+            b = position(lat, up.vertices[mod1(i + 1, 3)])
+            @test norm(b - a) ≈ 1.0 atol = 1e-10
+        end
+    end
+
+    @testset "Honeycomb: 1 hexagon per cell, 6 vertices, unit edges" begin
+        lat = build_lattice(Honeycomb, 6, 6)
+        @test num_elements(lat, PlaquetteCenter()) == 6 * 6
+        ps = collect(plaquettes(lat))
+        @test all(p.type === :hexagon for p in ps)
+        @test all(length(p.vertices) == 6 for p in ps)
+
+        # Pick an interior hexagon and check every edge is unit length.
+        target = SVector(3.0, 3.0)
+        k = argmin(norm(p.center - target) for p in ps)
+        p = ps[k]
+        n = length(p.vertices)
+        for i in 1:n
+            a = position(lat, p.vertices[i])
+            b = position(lat, p.vertices[mod1(i + 1, n)])
+            @test norm(b - a) ≈ 1.0 atol = 1e-10
+        end
+    end
+
+    @testset "Honeycomb: every site lives on exactly 3 hexagons (PBC)" begin
+        lat = build_lattice(Honeycomb, 4, 4)
+        ps = collect(plaquettes(lat))
+        counts = zeros(Int, num_sites(lat))
+        for p in ps
+            for v in p.vertices
+                counts[v] += 1
+            end
+        end
+        @test all(counts .== 3)
+    end
+
+    @testset "Kagome: 2 triangles per cell (hexagon not yet declared)" begin
+        lat = build_lattice(Kagome, 6, 6)
+        @test num_elements(lat, PlaquetteCenter()) == 2 * 6 * 6
+        ps = collect(plaquettes(lat))
+        @test count(p -> p.type === :up_triangle, ps) == 6 * 6
+        @test count(p -> p.type === :down_triangle, ps) == 6 * 6
+        @test all(length(p.vertices) == 3 for p in ps)
+    end
+
+    @testset "OBC drops plaquettes whose corners leave the sample" begin
+        # 4×4 honeycomb OBC: the hexagon rule uses corner offsets
+        # (0,0), (1,-1), (1,0), (0,1), (0,0). Valid anchor cells have
+        # cx ∈ [1, Lx-1] (dx=+1 reachable) and cy ∈ [2, Ly-1]
+        # (dy=-1 and dy=+1 both reachable), giving (Lx-1)*(Ly-2)
+        # surviving plaquettes.
+        for (Lx, Ly) in ((4, 4), (5, 4), (4, 5))
+            lat = build_lattice(Honeycomb, Lx, Ly; boundary=OpenAxis())
+            ps = collect(plaquettes(lat))
+            @test length(ps) == (Lx - 1) * (Ly - 2)
+            @test num_elements(lat, PlaquetteCenter()) == (Lx - 1) * (Ly - 2)
+        end
+
+        # Comparison to PBC: PBC version has Lx*Ly plaquettes.
+        @test length(collect(plaquettes(build_lattice(Honeycomb, 4, 4)))) == 16
+    end
+
+    @testset "topologies without plaquette rules return 0" begin
+        for Topo in (Lieb, ShastrySutherland, Dice, UnionJack)
+            lat = build_lattice(Topo, 3, 3)
+            @test num_elements(lat, PlaquetteCenter()) == 0
+            @test isempty(collect(plaquettes(lat)))
+        end
+    end
+
+    @testset "PlaquetteCenter delegates to plaquettes via element_position" begin
+        lat = build_lattice(Square, 4, 4)
+        for i in 1:num_elements(lat, PlaquetteCenter())
+            @test element_position(lat, PlaquetteCenter(), i) ==
+                collect(plaquettes(lat))[i].center
+        end
+    end
+
+    @testset "incident: bond ↔ plaquette round trip on Square" begin
+        lat = build_lattice(Square, 3, 3)
+        bs = collect(bonds(lat))
+        # Pick the first plaquette; its 4 boundary bonds must each
+        # list that plaquette in their own plaquette-incidence.
+        bond_ids = incident(lat, PlaquetteCenter(), BondCenter(), 1)
+        @test length(bond_ids) == 4
+        for b in bond_ids
+            @test 1 in incident(lat, BondCenter(), PlaquetteCenter(), b)
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Iteration 3b of the LatticeCore-first push. Wires `Lattice2D.Lattice` into the **plaquette abstraction** introduced in [LatticeCore #20](https://github.com/sotashimozono/LatticeCore.jl/pull/20).

> **Dependency**: LatticeCore 0.8.4. This PR uses a temporary `[sources]` pin to the LatticeCore branch `feat/plaquette-and-incidence` (SHA `ca46deb`). Remove the pin before merge, **or** merge after LatticeCore 0.8.4 is registered.

### What changed

- **`UnitCell{D,T}`** gains a fourth field `plaquettes::Vector{PlaquetteRule}`, defaulting to `[]` via a 3-arg back-compat constructor so topologies that haven't been wired up keep working unchanged.
- **`plaquettes(lat::Lattice)`** walks every `(cell_x, cell_y, rule_kind)` triple under the sample's boundary condition, filters rules whose corners exit the sample (strict — every corner must be valid), and materialises survivors into `Plaquette{2, Float64}` with cyclic vertex indices, the unwrapped centroid and the `type` tag from the rule.
- **`num_elements(::Lattice, ::PlaquetteCenter)`** counts directly from cells × rules without materialising a single `Plaquette`, so element-center code paths don't pay for full enumeration just to know the size.
- The previous local `bond_center` override on `::Lattice` is **removed** — LatticeCore 0.8.2 carries the upstream fix and this PR's `[sources]` pin points at 0.8.4.

### Topologies wired up

| topology | plaquette kinds |
| --- | --- |
| **Square** | 1 — `:square` (4 vertices, CCW) |
| **Triangular** | 2 — `:up_triangle`, `:down_triangle` |
| **Honeycomb** | 1 — `:hexagon` (6 vertices, CCW walk verified numerically to close with unit-length edges) |
| **Kagome** | 2 — `:up_triangle`, `:down_triangle` (the Kagome hexagon is left for a follow-up) |

**Left empty** (API wired, enumeration returns 0 plaquettes): Lieb, ShastrySutherland, Dice, UnionJack.

### Test plan

New `test/core/test_plaquettes.jl`:

- Plaquette count matches `Lx*Ly*kinds_per_cell` for every wired topology under PBC
- Square centroid lives at cell center
- Triangular: both triangle kinds present; interior up-triangle has unit-length edges
- Honeycomb: interior hexagon has 6 unit-length edges; every site is on exactly 3 hexagons under PBC
- Kagome: 2 triangle kinds, hexagon deliberately absent
- OBC drops plaquettes whose corners leave the sample — counted as `(Lx-1)*(Ly-2)` for Honeycomb
- Lieb/SS/Dice/UnionJack return 0 plaquettes via the element-center API
- `element_position(PlaquetteCenter(), i)` delegates to the i-th materialised plaquette's center
- `incident(PlaquetteCenter(), BondCenter(), p)` round-trips with `incident(BondCenter(), PlaquetteCenter(), b)` on Square

- [x] `Pkg.test()` — **1115 / 1115 pass** (was 1044, +71 new).

### Module surface

Re-exports `PlaquetteRule`, `Plaquette`, `plaquettes`, `neighbor_plaquettes`, `plaquette_center`, plus the full element-center API from LatticeCore #19 / #20 (`num_elements`, `elements`, `element_position`, `element_positions`, `element_neighbors`, `incident`).

Bumps version 0.2.3 → **0.2.4**.

## Type of Change

- [x] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)