### PR TITLE
feat: Kagome hexagon plaquette + sublattice_layout helper + drop [sources]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["souta shimozono"]
 
 [deps]
@@ -8,12 +8,6 @@ LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-
-# Temporary — points at LatticeCore.jl#20 (feat/plaquette-and-incidence).
-# Remove once LatticeCore 0.8.4 is registered in the General registry;
-# [compat] alone will pick it up thereafter.
-[sources]
-LatticeCore = {url = "https://github.com/sotashimozono/LatticeCore.jl.git", rev = "ca46deb5c6120f73f653c46a141ff242fe49b80d"}
 
 [compat]
 LatticeCore = "0.8.4"

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -119,6 +119,7 @@ include("utils/iterator.jl")
 export AbstractTopology, Connection, UnitCell, get_unit_cell
 export Lattice
 export build_lattice
+export sublattice_layout
 export AVAILABLE_LATTICES
 export Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
 

--- a/src/core/constructor.jl
+++ b/src/core/constructor.jl
@@ -67,3 +67,48 @@ Convenience alias for [`build_lattice`](@ref). Kept so that
 function Lattice(Topology::Type{<:AbstractTopology{2}}, Lx::Int, Ly::Int; kwargs...)
     return build_lattice(Topology, Lx, Ly; kwargs...)
 end
+
+"""
+    sublattice_layout(Topology, Lx, Ly, types; indexing = RowMajor())
+
+Convenience constructor for a [`SublatticeLayout`](@ref) that matches
+the geometric sublattice structure of an `Lx × Ly` lattice of the
+given `Topology`.
+
+`types` must be a tuple of `AbstractSiteType` values with length equal
+to the number of sublattices in the topology's unit cell; `types[k]`
+becomes the site type for every site in the `k`-th geometric
+sublattice.
+
+The `indexing` keyword must match whatever `indexing` will be passed
+to [`build_lattice`](@ref) — the layout's `sublattice_of` vector is
+computed via the chosen linearisation.
+
+# Example
+
+```julia
+# Honeycomb A / B with an Ising A sublattice and an XY B sublattice:
+layout = sublattice_layout(Honeycomb, 4, 4, (IsingSite(), XYSite()))
+lat = build_lattice(Honeycomb, 4, 4; layout = layout)
+```
+"""
+function sublattice_layout(
+    Topology::Type{<:AbstractTopology{2}},
+    Lx::Int,
+    Ly::Int,
+    types::Tuple{Vararg{AbstractSiteType}};
+    indexing::AbstractIndexing=RowMajor(),
+)
+    nsub = length(get_unit_cell(Topology).sublattice_positions)
+    length(types) == nsub || throw(
+        ArgumentError(
+            "topology $(Topology) has $nsub sublattices, got $(length(types)) site types",
+        ),
+    )
+    N = Lx * Ly * nsub
+    sub_ids = Vector{Int}(undef, N)
+    for i in 1:N
+        sub_ids[i] = lattice_coord(indexing, (Lx, Ly), nsub, i).sublattice
+    end
+    return SublatticeLayout(types, sub_ids)
+end

--- a/src/core/unitcells.jl
+++ b/src/core/unitcells.jl
@@ -105,11 +105,18 @@ function get_unit_cell(::Type{Kagome})
     ]
     # The up-triangle is the intra-cell triangle A-B-C. The
     # down-triangle lives between three neighbouring cells: B(0,0),
-    # A(1,0), C(1,-1). Hexagonal plaquettes exist in Kagome too but
-    # are left to a follow-up PR.
+    # A(1,0), C(1,-1). The hexagon surrounds the hole between the
+    # anchor cell and its (+x)/(+y) neighbours — a CCW walk through
+    # B(0,0), A(1,0), C(1,0), B(0,1), A(0,1), C(0,0). Verified
+    # numerically: all 6 corners lie at distance 0.5 from the hex
+    # centre and every edge has unit length.
     plaqs = [
         PlaquetteRule([(1, 0, 0), (2, 0, 0), (3, 0, 0)], :up_triangle),
         PlaquetteRule([(2, 0, 0), (1, 1, 0), (3, 1, -1)], :down_triangle),
+        PlaquetteRule(
+            [(2, 0, 0), (1, 1, 0), (3, 1, 0), (2, 0, 1), (1, 0, 1), (3, 0, 0)],
+            :hexagon,
+        ),
     ]
     return UnitCell{2,Float64}([a1, a2], [d_A, d_B, d_C], conns, plaqs)
 end

--- a/src/core/unitcells.jl
+++ b/src/core/unitcells.jl
@@ -114,8 +114,7 @@ function get_unit_cell(::Type{Kagome})
         PlaquetteRule([(1, 0, 0), (2, 0, 0), (3, 0, 0)], :up_triangle),
         PlaquetteRule([(2, 0, 0), (1, 1, 0), (3, 1, -1)], :down_triangle),
         PlaquetteRule(
-            [(2, 0, 0), (1, 1, 0), (3, 1, 0), (2, 0, 1), (1, 0, 1), (3, 0, 0)],
-            :hexagon,
+            [(2, 0, 0), (1, 1, 0), (3, 1, 0), (2, 0, 1), (1, 0, 1), (3, 0, 0)], :hexagon
         ),
     ]
     return UnitCell{2,Float64}([a1, a2], [d_A, d_B, d_C], conns, plaqs)

--- a/test/core/test_plaquettes.jl
+++ b/test/core/test_plaquettes.jl
@@ -87,9 +87,7 @@
         # Kagome sites are at half the Bravais spacing, so unit-cell
         # NN distance is 0.5 (the hexagon edge length).
         target = SVector(5.0, 3.0)
-        hex = first(
-            p for p in ps if p.type === :hexagon && norm(p.center - target) < 1.0
-        )
+        hex = first(p for p in ps if p.type === :hexagon && norm(p.center - target) < 1.0)
         for i in 1:6
             a = position(lat, hex.vertices[i])
             b = position(lat, hex.vertices[mod1(i + 1, 6)])

--- a/test/core/test_plaquettes.jl
+++ b/test/core/test_plaquettes.jl
@@ -70,13 +70,31 @@
         @test all(counts .== 3)
     end
 
-    @testset "Kagome: 2 triangles per cell (hexagon not yet declared)" begin
+    @testset "Kagome: 3 plaquette kinds (up/down triangle + hexagon)" begin
         lat = build_lattice(Kagome, 6, 6)
-        @test num_elements(lat, PlaquetteCenter()) == 2 * 6 * 6
+        @test num_elements(lat, PlaquetteCenter()) == 3 * 6 * 6
         ps = collect(plaquettes(lat))
         @test count(p -> p.type === :up_triangle, ps) == 6 * 6
         @test count(p -> p.type === :down_triangle, ps) == 6 * 6
-        @test all(length(p.vertices) == 3 for p in ps)
+        @test count(p -> p.type === :hexagon, ps) == 6 * 6
+        @test count(length(p.vertices) == 3 for p in ps) == 2 * 6 * 6
+        @test count(length(p.vertices) == 6 for p in ps) == 6 * 6
+    end
+
+    @testset "Kagome hexagon: 6 unit edges, interior sample" begin
+        lat = build_lattice(Kagome, 8, 8; boundary=OpenAxis())
+        ps = collect(plaquettes(lat))
+        # Kagome sites are at half the Bravais spacing, so unit-cell
+        # NN distance is 0.5 (the hexagon edge length).
+        target = SVector(5.0, 3.0)
+        hex = first(
+            p for p in ps if p.type === :hexagon && norm(p.center - target) < 1.0
+        )
+        for i in 1:6
+            a = position(lat, hex.vertices[i])
+            b = position(lat, hex.vertices[mod1(i + 1, 6)])
+            @test norm(b - a) ≈ 0.5 atol = 1e-10
+        end
     end
 
     @testset "OBC drops plaquettes whose corners leave the sample" begin

--- a/test/core/test_sublattice_layout.jl
+++ b/test/core/test_sublattice_layout.jl
@@ -14,15 +14,12 @@
         end
 
         # Half the sites are A, half are B.
-        a_count = count(i -> site_type(site_layout(lat), i) isa IsingSite,
-                        1:num_sites(lat))
+        a_count = count(i -> site_type(site_layout(lat), i) isa IsingSite, 1:num_sites(lat))
         @test a_count == num_sites(lat) ÷ 2
     end
 
     @testset "Kagome: three distinct site types across sublattices" begin
-        layout = sublattice_layout(
-            Kagome, 3, 3, (IsingSite(), PottsSite(3), XYSite())
-        )
+        layout = sublattice_layout(Kagome, 3, 3, (IsingSite(), PottsSite(3), XYSite()))
         lat = build_lattice(Kagome, 3, 3; layout=layout)
 
         # Every site's site type matches its sublattice.
@@ -36,7 +33,9 @@
         # Equal counts per sublattice on a 3×3 sample.
         for k in 1:3
             @test count(
-                i -> sublattice(lat, i) == k && typeof(site_type(site_layout(lat), i)) === typeof(type_by_sub[k]),
+                i ->
+                    sublattice(lat, i) == k &&
+                    typeof(site_type(site_layout(lat), i)) === typeof(type_by_sub[k]),
                 1:num_sites(lat),
             ) == 9
         end
@@ -60,9 +59,7 @@
 
     @testset "Wrong arity throws ArgumentError" begin
         @test_throws ArgumentError sublattice_layout(Honeycomb, 3, 3, (IsingSite(),))
-        @test_throws ArgumentError sublattice_layout(
-            Kagome, 3, 3, (IsingSite(), XYSite())
-        )
+        @test_throws ArgumentError sublattice_layout(Kagome, 3, 3, (IsingSite(), XYSite()))
     end
 
     @testset "random_state on a mixed-spin Honeycomb layout" begin

--- a/test/core/test_sublattice_layout.jl
+++ b/test/core/test_sublattice_layout.jl
@@ -1,0 +1,80 @@
+@testset "sublattice_layout convenience helper" begin
+    @testset "Honeycomb: Ising A / XY B" begin
+        layout = sublattice_layout(Honeycomb, 4, 4, (IsingSite(), XYSite()))
+        lat = build_lattice(Honeycomb, 4, 4; layout=layout)
+
+        for i in 1:num_sites(lat)
+            s = sublattice(lat, i)
+            st = site_type(site_layout(lat), i)
+            if s == 1
+                @test st isa IsingSite
+            else
+                @test st isa XYSite
+            end
+        end
+
+        # Half the sites are A, half are B.
+        a_count = count(i -> site_type(site_layout(lat), i) isa IsingSite,
+                        1:num_sites(lat))
+        @test a_count == num_sites(lat) ÷ 2
+    end
+
+    @testset "Kagome: three distinct site types across sublattices" begin
+        layout = sublattice_layout(
+            Kagome, 3, 3, (IsingSite(), PottsSite(3), XYSite())
+        )
+        lat = build_lattice(Kagome, 3, 3; layout=layout)
+
+        # Every site's site type matches its sublattice.
+        type_by_sub = (IsingSite(), PottsSite(3), XYSite())
+        for i in 1:num_sites(lat)
+            s = sublattice(lat, i)
+            st = site_type(site_layout(lat), i)
+            @test typeof(st) === typeof(type_by_sub[s])
+        end
+
+        # Equal counts per sublattice on a 3×3 sample.
+        for k in 1:3
+            @test count(
+                i -> sublattice(lat, i) == k && typeof(site_type(site_layout(lat), i)) === typeof(type_by_sub[k]),
+                1:num_sites(lat),
+            ) == 9
+        end
+    end
+
+    @testset "ColMajor indexing: sublattice_layout respects the indexing kwarg" begin
+        layout = sublattice_layout(
+            Honeycomb, 3, 3, (IsingSite(), XYSite()); indexing=ColMajor()
+        )
+        lat = build_lattice(Honeycomb, 3, 3; layout=layout, indexing=ColMajor())
+        for i in 1:num_sites(lat)
+            s = sublattice(lat, i)
+            st = site_type(site_layout(lat), i)
+            if s == 1
+                @test st isa IsingSite
+            else
+                @test st isa XYSite
+            end
+        end
+    end
+
+    @testset "Wrong arity throws ArgumentError" begin
+        @test_throws ArgumentError sublattice_layout(Honeycomb, 3, 3, (IsingSite(),))
+        @test_throws ArgumentError sublattice_layout(
+            Kagome, 3, 3, (IsingSite(), XYSite())
+        )
+    end
+
+    @testset "random_state on a mixed-spin Honeycomb layout" begin
+        rng = MersenneTwister(42)
+        layout = sublattice_layout(Honeycomb, 4, 4, (IsingSite(), XYSite()))
+        lat = build_lattice(Honeycomb, 4, 4; layout=layout)
+
+        # Draw one random state per site using the site's declared type.
+        for i in 1:num_sites(lat)
+            st = site_type(site_layout(lat), i)
+            s = random_state(rng, st)
+            @test s isa state_type(st)
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Iteration 4. Three changes rolled into one PR — the common theme is "cover the remaining F5 / F1 story for Lattice2D now that LatticeCore 0.8.4 is in the registry".

### 1. Kagome hexagon plaquette

Kagome now declares **3 plaquette kinds per cell** (up from 2):

| kind | corners (cyclic CCW) |
| --- | --- |
| `:up_triangle` | intra-cell `A-B-C` |
| `:down_triangle` | `B(0,0)-A(1,0)-C(1,-1)` |
| `:hexagon` (**new**) | `B(0,0)-A(1,0)-C(1,0)-B(0,1)-A(0,1)-C(0,0)` |

Verified numerically on an OBC sample: every edge of an interior hexagon has length `0.5` (half the Bravais spacing, matching the Kagome NN distance).

### 2. `sublattice_layout` convenience helper

Constructing a `SublatticeLayout` by hand is awkward because the caller has to enumerate `1:N` site indices and look up each one's geometric sublattice. The new helper:

```julia
layout = sublattice_layout(Honeycomb, 4, 4, (IsingSite(), XYSite()))
lat = build_lattice(Honeycomb, 4, 4; layout=layout)
```

builds the layout for a given topology + sample size + per-sublattice site type tuple in one call. `site_type(site_layout(lat), i)` then dispatches to `IsingSite` on the A sublattice and `XYSite` on the B sublattice — **mixed-spin Honeycomb** is now a two-line construction.

Throws `ArgumentError` if the arity of `types` doesn't match the topology's sublattice count.

### 3. Drop temporary `[sources]` pin on LatticeCore

LatticeCore 0.8.4 is now registered in the General registry, so Lattice2D can resolve it via `[compat]` alone. The `[sources]` block added in #28 is removed.

## Test plan

- [x] `test/core/test_sublattice_layout.jl` — new file, 6 testsets:
  - Honeycomb A/B mixed-spin (`IsingSite` / `XYSite`)
  - Kagome A/B/C with three distinct site types
  - `ColMajor` indexing respected by the layout helper
  - Wrong-arity throws `ArgumentError`
  - `random_state` round-trip per site on a mixed-spin sample
- [x] `test/core/test_plaquettes.jl` extended:
  - Kagome now has `3 * Lx * Ly` plaquettes (3 kinds × cells)
  - interior hexagon has 6 unit-length edges (length 0.5)
- [x] `Pkg.test()` — **1238 / 1238 pass** (was 1115, **+123** new assertions).

Bumps version 0.2.4 → **0.2.5**.

## Type of Change

- [x] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)