### PR TITLE
feat: plaquettes for Lieb / ShastrySutherland / UnionJack

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["souta shimozono"]
 
 [deps]

--- a/src/core/unitcells.jl
+++ b/src/core/unitcells.jl
@@ -143,7 +143,23 @@ function get_unit_cell(::Type{Lieb})
         Connection(2, 1, 1, 0, 1),     # B → next A (right)
         Connection(3, 1, 0, 1, 2),     # C → next A (up)
     ]
-    return UnitCell{2,Float64}([a1, a2], [d_A, d_B, d_C], conns)
+    # One plaquette per cell: the 2×2 square with 4 corner A's and 4
+    # edge sites (2 B's bottom/top, 2 C's left/right). CCW walk:
+    #   A(0,0) → B(0,0) → A(1,0) → C(1,0) → A(1,1) → B(0,1) → A(0,1) → C(0,0)
+    plaqs = [PlaquetteRule(
+        [
+            (1, 0, 0),   # A(0,0) — bottom-left corner
+            (2, 0, 0),   # B(0,0) — bottom edge
+            (1, 1, 0),   # A(1,0) — bottom-right corner
+            (3, 1, 0),   # C(1,0) — right edge
+            (1, 1, 1),   # A(1,1) — top-right corner
+            (2, 0, 1),   # B(0,1) — top edge
+            (1, 0, 1),   # A(0,1) — top-left corner
+            (3, 0, 0),   # C(0,0) — left edge
+        ],
+        :square,
+    )]
+    return UnitCell{2,Float64}([a1, a2], [d_A, d_B, d_C], conns, plaqs)
 end
 
 """
@@ -182,7 +198,34 @@ function get_unit_cell(::Type{ShastrySutherland})
         Connection(1, 4, 0, 0, 2),     # 1–4 (same cell diagonal)
         Connection(2, 3, 1, -1, 2),    # 2–3 (down-right diagonal)
     ]
-    return UnitCell{2,Float64}([a1, a2], [d_1, d_2, d_3, d_4], conns)
+    # Four small unit-squares per cell (the underlying square lattice
+    # has 2Lx × 2Ly sites on a 2×2 sublattice unit cell, so 4 small
+    # squares per cell). Each small square is walked CCW; the `type`
+    # tag distinguishes squares that contain an intra-cell J' dimer
+    # from those that don't.
+    #   P1 (bottom-left, contains the 1-4 dimer):
+    #     (0,0)-(1,0)-(1,1)-(0,1)  = sub 1,2,4,3
+    #   P2 (bottom-right, dimer-free):
+    #     (1,0)-(2,0)-(2,1)-(1,1)  = sub 2@(0,0), 1@(1,0), 3@(1,0), 4@(0,0)
+    #   P3 (top-left, dimer-free):
+    #     (0,1)-(1,1)-(1,2)-(0,2)  = sub 3@(0,0), 4@(0,0), 2@(0,1), 1@(0,1)
+    #   P4 (top-right, contains the 2-3 dimer under cell shift):
+    #     (1,1)-(2,1)-(2,2)-(1,2)  = sub 4@(0,0), 3@(1,0), 1@(1,1), 2@(0,1)
+    plaqs = [
+        PlaquetteRule(
+            [(1, 0, 0), (2, 0, 0), (4, 0, 0), (3, 0, 0)], :dimer_square
+        ),
+        PlaquetteRule(
+            [(2, 0, 0), (1, 1, 0), (3, 1, 0), (4, 0, 0)], :square
+        ),
+        PlaquetteRule(
+            [(3, 0, 0), (4, 0, 0), (2, 0, 1), (1, 0, 1)], :square
+        ),
+        PlaquetteRule(
+            [(4, 0, 0), (3, 1, 0), (1, 1, 1), (2, 0, 1)], :dimer_square
+        ),
+    ]
+    return UnitCell{2,Float64}([a1, a2], [d_1, d_2, d_3, d_4], conns, plaqs)
 end
 
 """
@@ -242,7 +285,19 @@ function get_unit_cell(::Type{UnionJack})
         Connection(1, 2, 0, -1, 1),    # A → B (down)
         Connection(1, 2, -1, -1, 1),   # A → B (down-left)
     ]
-    return UnitCell{2,Float64}([a1, a2], [d_A, d_B], conns)
+    # Four small triangles per cell, each sharing the body site B.
+    # The four corner A's are walked in CCW order around B(0,0):
+    #   T1 (south): A(0,0), A(1,0), B(0,0)
+    #   T2 (east) : A(1,0), A(1,1), B(0,0)
+    #   T3 (north): A(1,1), A(0,1), B(0,0)
+    #   T4 (west) : A(0,1), A(0,0), B(0,0)
+    plaqs = [
+        PlaquetteRule([(1, 0, 0), (1, 1, 0), (2, 0, 0)], :triangle_south),
+        PlaquetteRule([(1, 1, 0), (1, 1, 1), (2, 0, 0)], :triangle_east),
+        PlaquetteRule([(1, 1, 1), (1, 0, 1), (2, 0, 0)], :triangle_north),
+        PlaquetteRule([(1, 0, 1), (1, 0, 0), (2, 0, 0)], :triangle_west),
+    ]
+    return UnitCell{2,Float64}([a1, a2], [d_A, d_B], conns, plaqs)
 end
 
 """Tuple listing every topology shipped by Lattice2D."""

--- a/src/core/unitcells.jl
+++ b/src/core/unitcells.jl
@@ -146,19 +146,21 @@ function get_unit_cell(::Type{Lieb})
     # One plaquette per cell: the 2×2 square with 4 corner A's and 4
     # edge sites (2 B's bottom/top, 2 C's left/right). CCW walk:
     #   A(0,0) → B(0,0) → A(1,0) → C(1,0) → A(1,1) → B(0,1) → A(0,1) → C(0,0)
-    plaqs = [PlaquetteRule(
-        [
-            (1, 0, 0),   # A(0,0) — bottom-left corner
-            (2, 0, 0),   # B(0,0) — bottom edge
-            (1, 1, 0),   # A(1,0) — bottom-right corner
-            (3, 1, 0),   # C(1,0) — right edge
-            (1, 1, 1),   # A(1,1) — top-right corner
-            (2, 0, 1),   # B(0,1) — top edge
-            (1, 0, 1),   # A(0,1) — top-left corner
-            (3, 0, 0),   # C(0,0) — left edge
-        ],
-        :square,
-    )]
+    plaqs = [
+        PlaquetteRule(
+            [
+                (1, 0, 0),   # A(0,0) — bottom-left corner
+                (2, 0, 0),   # B(0,0) — bottom edge
+                (1, 1, 0),   # A(1,0) — bottom-right corner
+                (3, 1, 0),   # C(1,0) — right edge
+                (1, 1, 1),   # A(1,1) — top-right corner
+                (2, 0, 1),   # B(0,1) — top edge
+                (1, 0, 1),   # A(0,1) — top-left corner
+                (3, 0, 0),   # C(0,0) — left edge
+            ],
+            :square,
+        ),
+    ]
     return UnitCell{2,Float64}([a1, a2], [d_A, d_B, d_C], conns, plaqs)
 end
 
@@ -212,18 +214,10 @@ function get_unit_cell(::Type{ShastrySutherland})
     #   P4 (top-right, contains the 2-3 dimer under cell shift):
     #     (1,1)-(2,1)-(2,2)-(1,2)  = sub 4@(0,0), 3@(1,0), 1@(1,1), 2@(0,1)
     plaqs = [
-        PlaquetteRule(
-            [(1, 0, 0), (2, 0, 0), (4, 0, 0), (3, 0, 0)], :dimer_square
-        ),
-        PlaquetteRule(
-            [(2, 0, 0), (1, 1, 0), (3, 1, 0), (4, 0, 0)], :square
-        ),
-        PlaquetteRule(
-            [(3, 0, 0), (4, 0, 0), (2, 0, 1), (1, 0, 1)], :square
-        ),
-        PlaquetteRule(
-            [(4, 0, 0), (3, 1, 0), (1, 1, 1), (2, 0, 1)], :dimer_square
-        ),
+        PlaquetteRule([(1, 0, 0), (2, 0, 0), (4, 0, 0), (3, 0, 0)], :dimer_square),
+        PlaquetteRule([(2, 0, 0), (1, 1, 0), (3, 1, 0), (4, 0, 0)], :square),
+        PlaquetteRule([(3, 0, 0), (4, 0, 0), (2, 0, 1), (1, 0, 1)], :square),
+        PlaquetteRule([(4, 0, 0), (3, 1, 0), (1, 1, 1), (2, 0, 1)], :dimer_square),
     ]
     return UnitCell{2,Float64}([a1, a2], [d_1, d_2, d_3, d_4], conns, plaqs)
 end

--- a/test/core/test_plaquettes.jl
+++ b/test/core/test_plaquettes.jl
@@ -158,8 +158,7 @@
             found = false
             for (i, j) in ((1, 3), (2, 4))
                 edge = (
-                    min(p.vertices[i], p.vertices[j]),
-                    max(p.vertices[i], p.vertices[j]),
+                    min(p.vertices[i], p.vertices[j]), max(p.vertices[i], p.vertices[j])
                 )
                 if edge in dimer_edges
                     found = true

--- a/test/core/test_plaquettes.jl
+++ b/test/core/test_plaquettes.jl
@@ -112,12 +112,89 @@
         @test length(collect(plaquettes(build_lattice(Honeycomb, 4, 4)))) == 16
     end
 
-    @testset "topologies without plaquette rules return 0" begin
-        for Topo in (Lieb, ShastrySutherland, Dice, UnionJack)
-            lat = build_lattice(Topo, 3, 3)
-            @test num_elements(lat, PlaquetteCenter()) == 0
-            @test isempty(collect(plaquettes(lat)))
+    @testset "Lieb: one 8-vertex square per cell" begin
+        lat = build_lattice(Lieb, 4, 4)
+        @test num_elements(lat, PlaquetteCenter()) == 4 * 4
+        ps = collect(plaquettes(lat))
+        @test all(p.type === :square for p in ps)
+        @test all(length(p.vertices) == 8 for p in ps)
+
+        # Interior plaquette anchored at cell (1,1) has centroid
+        # (1.0, 1.0) and every edge has unit length.
+        p = first(p for p in ps if p.center ≈ SVector(1.0, 1.0))
+        for i in 1:8
+            a = position(lat, p.vertices[i])
+            b = position(lat, p.vertices[mod1(i + 1, 8)])
+            @test norm(b - a) ≈ 1.0 atol = 1e-10
         end
+    end
+
+    @testset "ShastrySutherland: 4 small squares per cell, half dimer" begin
+        for (Lx, Ly) in ((3, 3), (4, 4))
+            lat = build_lattice(ShastrySutherland, Lx, Ly)
+            @test num_elements(lat, PlaquetteCenter()) == 4 * Lx * Ly
+            ps = collect(plaquettes(lat))
+            @test count(p -> p.type === :dimer_square, ps) == 2 * Lx * Ly
+            @test count(p -> p.type === :square, ps) == 2 * Lx * Ly
+            @test all(length(p.vertices) == 4 for p in ps)
+        end
+    end
+
+    @testset "ShastrySutherland: every dimer_square has a J' dimer inside" begin
+        lat = build_lattice(ShastrySutherland, 3, 3)
+        ps = collect(plaquettes(lat))
+        # Dimer bonds are those with type :type_2 in Lattice2D's bond
+        # tagging (Connection.type = 2 for the diagonals).
+        dimer_edges = Set{Tuple{Int,Int}}()
+        for b in bonds(lat)
+            if b.type === :type_2
+                push!(dimer_edges, (min(b.i, b.j), max(b.i, b.j)))
+            end
+        end
+
+        for p in ps
+            p.type === :dimer_square || continue
+            # CCW-ordered 4 corners ⇒ opposite corners are (1,3) and (2,4).
+            found = false
+            for (i, j) in ((1, 3), (2, 4))
+                edge = (
+                    min(p.vertices[i], p.vertices[j]),
+                    max(p.vertices[i], p.vertices[j]),
+                )
+                if edge in dimer_edges
+                    found = true
+                    break
+                end
+            end
+            @test found
+        end
+    end
+
+    @testset "UnionJack: 4 triangle kinds per cell, 3 vertices each" begin
+        lat = build_lattice(UnionJack, 4, 4)
+        @test num_elements(lat, PlaquetteCenter()) == 4 * 4 * 4
+        ps = collect(plaquettes(lat))
+        for ty in (:triangle_south, :triangle_east, :triangle_north, :triangle_west)
+            @test count(p -> p.type === ty, ps) == 16
+        end
+        @test all(length(p.vertices) == 3 for p in ps)
+    end
+
+    @testset "UnionJack: every triangle has one body + two corners" begin
+        lat = build_lattice(UnionJack, 4, 4)
+        ps = collect(plaquettes(lat))
+        for p in ps
+            sub_ids = [sublattice(lat, v) for v in p.vertices]
+            @test count(==(1), sub_ids) == 2
+            @test count(==(2), sub_ids) == 1
+        end
+    end
+
+    @testset "Dice still has no plaquette rules declared" begin
+        # Dice (T3) rhombus plaquettes are left for a follow-up PR.
+        lat = build_lattice(Dice, 3, 3)
+        @test num_elements(lat, PlaquetteCenter()) == 0
+        @test isempty(collect(plaquettes(lat)))
     end
 
     @testset "PlaquetteCenter delegates to plaquettes via element_position" begin


### PR DESCRIPTION
## Summary

Iteration 5. Extends `PlaquetteRule` coverage to three more topologies. Dice is still deferred pending a clean CCW rhombus convention for its T3 structure.

> **Base branch**: this PR is stacked on top of [#29 (feat/iter4-sublattice-kagome)](https://github.com/sotashimozono/Lattice2D.jl/pull/29) because that PR hasn't landed yet. Merge #29 first, or re-target to `main` after.

### New plaquette rules

| topology | kinds per cell | details |
| --- | --- | --- |
| **Lieb** | 1 — `:square` | 8-vertex walk: 4 corner A's + 4 edge sites (B on bottom/top, C on left/right). Every edge is unit length. |
| **ShastrySutherland** | 4 — 2×`:dimer_square` + 2×`:square` | The underlying 2L×2L square lattice partitioned into small squares. Two of the four kinds contain an intra-plaquette J′ dimer on their diagonal; the other two are dimer-free. |
| **UnionJack** | 4 — `:triangle_{south,east,north,west}` | Four small triangles sharing the body-centred B site, walked CCW around B. Each triangle has 2 corner A's + 1 body B. |

Dice (T3) still returns 0 plaquettes — covered by a regression test pinning this until a dedicated follow-up handles the rhombi.

### Test plan

- [x] Lieb 4×4 PBC: 16 plaquettes, all 8-vertex, interior hexagon-free "square" at centroid (1.0, 1.0) with 8 unit-length edges
- [x] ShastrySutherland 3×3 / 4×4 PBC: `4*Lx*Ly` plaquettes, 50/50 split between `:dimer_square` and `:square`
- [x] ShastrySutherland: **every `:dimer_square` has a `:type_2` (J′) bond on one of its diagonals** — verified by walking the bond list and checking the opposite-corner pair
- [x] UnionJack 4×4 PBC: 64 plaquettes, 16 per compass direction, each triangle has 2 A corners + 1 B body
- [x] Dice: still 0 plaquettes (pinned for regression)
- [x] `Pkg.test()` — **1403 / 1403 pass** (was 1238, **+165** new assertions)

Bumps version 0.2.5 → **0.2.6**.

## Type of Change

- [x] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)