### PR TITLE
feat: LatticeCache for O(local) element-center and incidence API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["souta shimozono"]
 
 [deps]

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -110,6 +110,8 @@ import LatticeCore:
 include("core/topology.jl")
 include("core/unitcells.jl")
 include("core/lattice.jl")
+include("core/cache.jl")
+include("core/element_api.jl")
 include("core/constructor.jl")
 include("utils/iterator.jl")
 

--- a/src/core/cache.jl
+++ b/src/core/cache.jl
@@ -1,0 +1,95 @@
+"""
+    LatticeCache{T}
+
+Lazy, per-lattice cache of bonds, plaquettes, and the reverse-lookup
+tables needed to make the element-center / incidence API O(local)
+instead of O(num_bonds + num_plaquettes) per call.
+
+The cache is constructed once on first access through
+[`_get_cache`](@ref) and lives inside a `Ref` field on the parent
+[`Lattice`](@ref), so the struct itself stays immutable and cheap to
+copy. For sizes typical of MC work (10⁴–10⁶ sites), the cache
+occupies a few hundred kilobytes and is negligible relative to the
+state vectors MC actually keeps hot.
+
+Fields
+
+- `bonds::Vector{Bond{2, T}}` — materialised bond list, ordered by
+  `(cell_y, cell_x, connection_index)` just like the generic
+  `bonds(lat)` iteration.
+- `plaquettes::Vector{Plaquette{2, T}}` — materialised plaquette
+  list, ordered by `(cell_y, cell_x, rule_index)`.
+- `bond_index_of::Dict{Tuple{Int, Int}, Int}` — `(min_i, max_j) →
+  integer bond index`. Keyed by the canonical (smaller, larger)
+  endpoint tuple so that `bond_index_of[(min(i, j), max(i, j))]`
+  always hits regardless of which endpoint walked first.
+- `plaquettes_by_vertex::Vector{Vector{Int}}` — per-site list of
+  plaquette indices whose boundary contains that site.
+- `plaquettes_by_bond::Dict{Tuple{Int, Int}, Vector{Int}}` — per-bond
+  list of plaquette indices that have that bond on their boundary.
+  Same canonical `(min, max)` keying as `bond_index_of`.
+"""
+struct LatticeCache{T<:AbstractFloat}
+    bonds::Vector{Bond{2,T}}
+    plaquettes::Vector{Plaquette{2,T}}
+    bond_index_of::Dict{Tuple{Int,Int},Int}
+    plaquettes_by_vertex::Vector{Vector{Int}}
+    plaquettes_by_bond::Dict{Tuple{Int,Int},Vector{Int}}
+end
+
+@inline _edge_key(i::Int, j::Int) = (min(i, j), max(i, j))
+
+"""
+    _build_lattice_cache(lat::Lattice{Topo, T}) → LatticeCache{T}
+
+Populate the full cache in a single pass over the lattice. Called
+once on first cache access through [`_get_cache`](@ref).
+"""
+function _build_lattice_cache(lat::Lattice{Topo,T}) where {Topo,T}
+    # ---- Bonds via the existing generator --------------------------
+    bond_vec = collect(
+        b for i in 1:num_sites(lat) for b in neighbor_bonds(lat, i) if b.j > b.i
+    )
+    bond_index_of = Dict{Tuple{Int,Int},Int}()
+    sizehint!(bond_index_of, length(bond_vec))
+    for (k, b) in enumerate(bond_vec)
+        bond_index_of[_edge_key(b.i, b.j)] = k
+    end
+
+    # ---- Plaquettes via the existing materialiser ------------------
+    plaq_vec = _materialise_plaquettes(lat)
+
+    N = num_sites(lat)
+    plaquettes_by_vertex = [Int[] for _ in 1:N]
+    plaquettes_by_bond = Dict{Tuple{Int,Int},Vector{Int}}()
+
+    for (p_idx, p) in enumerate(plaq_vec)
+        vs = p.vertices
+        n = length(vs)
+        for v in vs
+            push!(plaquettes_by_vertex[v], p_idx)
+        end
+        for k in 1:n
+            key = _edge_key(vs[k], vs[mod1(k + 1, n)])
+            lst = get!(() -> Int[], plaquettes_by_bond, key)
+            push!(lst, p_idx)
+        end
+    end
+
+    return LatticeCache{T}(
+        bond_vec, plaq_vec, bond_index_of, plaquettes_by_vertex, plaquettes_by_bond
+    )
+end
+
+"""
+    _get_cache(lat::Lattice{Topo, T}) → LatticeCache{T}
+
+Return the lattice's per-sample cache, populating it on first access.
+"""
+function _get_cache(lat::Lattice{Topo,T}) where {Topo,T}
+    ref = lat.cache
+    if ref[] === nothing
+        ref[] = _build_lattice_cache(lat)
+    end
+    return ref[]::LatticeCache{T}
+end

--- a/src/core/constructor.jl
+++ b/src/core/constructor.jl
@@ -54,7 +54,7 @@ function build_lattice(
     bc = _resolve_boundary(boundary)
     T = Float64
     return Lattice{Topology,T,typeof(bc),typeof(indexing),typeof(layout)}(
-        Lx, Ly, bc, indexing, layout
+        Lx, Ly, bc, indexing, layout, Ref{Any}(nothing)
     )
 end
 

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -1,0 +1,136 @@
+"""
+    element_api.jl
+
+Specialised element-center and incidence methods for
+[`Lattice2D.Lattice`](@ref) that pull from the lazy
+[`LatticeCache`](@ref) instead of materialising everything on every
+call. Include order-wise this file has to come after `lattice.jl`
+(for the `Lattice` type and `_materialise_plaquettes`) and
+`cache.jl` (for `LatticeCache` and `_get_cache`).
+
+The overrides here replace LatticeCore's correctness-only O(N)
+defaults — the lattice still implements the same contract, callers
+just stop paying O(num_bonds) per element-position lookup.
+"""
+
+# ---- Bond and plaquette enumeration through the cache --------------
+
+LatticeCore.bonds(lat::Lattice) = _get_cache(lat).bonds
+
+LatticeCore.plaquettes(lat::Lattice) = _get_cache(lat).plaquettes
+
+# ---- Element counts ------------------------------------------------
+
+LatticeCore.num_elements(lat::Lattice, ::VertexCenter) = num_sites(lat)
+LatticeCore.num_elements(lat::Lattice, ::BondCenter) = length(_get_cache(lat).bonds)
+function LatticeCore.num_elements(lat::Lattice, ::PlaquetteCenter)
+    return length(_get_cache(lat).plaquettes)
+end
+
+# ---- Element iteration --------------------------------------------
+
+LatticeCore.elements(lat::Lattice, ::VertexCenter) = 1:num_sites(lat)
+LatticeCore.elements(lat::Lattice, ::BondCenter) = _get_cache(lat).bonds
+LatticeCore.elements(lat::Lattice, ::PlaquetteCenter) = _get_cache(lat).plaquettes
+
+# ---- Element positions: O(1) via cached Vector --------------------
+
+function LatticeCore.element_position(lat::Lattice, ::BondCenter, i::Int)
+    b = _get_cache(lat).bonds[i]
+    return bond_center(lat, b)
+end
+
+function LatticeCore.element_position(lat::Lattice, ::PlaquetteCenter, i::Int)
+    return _get_cache(lat).plaquettes[i].center
+end
+
+# ---- Same-centring adjacency: O(degree) / O(boundary) -------------
+
+function LatticeCore.element_neighbors(lat::Lattice, ::BondCenter, i::Int)
+    cache = _get_cache(lat)
+    b = cache.bonds[i]
+    seen = Set{Int}()
+    # Bonds incident to either endpoint, excluding b itself.
+    for endpoint in (b.i, b.j)
+        for nb in neighbor_bonds(lat, endpoint)
+            key = _edge_key(nb.i, nb.j)
+            idx = get(cache.bond_index_of, key, 0)
+            idx == 0 && continue
+            idx == i && continue
+            push!(seen, idx)
+        end
+    end
+    return sort!(collect(seen))
+end
+
+function LatticeCore.element_neighbors(lat::Lattice, ::PlaquetteCenter, i::Int)
+    cache = _get_cache(lat)
+    p = cache.plaquettes[i]
+    seen = Set{Int}()
+    vs = p.vertices
+    n = length(vs)
+    for k in 1:n
+        key = _edge_key(vs[k], vs[mod1(k + 1, n)])
+        for q in get(cache.plaquettes_by_bond, key, Int[])
+            q == i && continue
+            push!(seen, q)
+        end
+    end
+    return sort!(collect(seen))
+end
+
+# ---- Cross-centring incidence: O(local) ---------------------------
+
+# Vertex → Bond: bonds touching site i. `neighbor_bonds` gives us
+# the incident Bond objects directly; translate each to its canonical
+# integer index via the cache's reverse-lookup dict.
+function LatticeCore.incident(lat::Lattice, ::VertexCenter, ::BondCenter, i::Int)
+    cache = _get_cache(lat)
+    out = Int[]
+    for b in neighbor_bonds(lat, i)
+        key = _edge_key(b.i, b.j)
+        idx = get(cache.bond_index_of, key, 0)
+        idx == 0 || push!(out, idx)
+    end
+    return out
+end
+
+# Bond → Vertex: endpoints are in the cached Bond object.
+function LatticeCore.incident(lat::Lattice, ::BondCenter, ::VertexCenter, i::Int)
+    b = _get_cache(lat).bonds[i]
+    return [b.i, b.j]
+end
+
+# Vertex → Plaquette: cached per-vertex list.
+function LatticeCore.incident(lat::Lattice, ::VertexCenter, ::PlaquetteCenter, i::Int)
+    return copy(_get_cache(lat).plaquettes_by_vertex[i])
+end
+
+# Plaquette → Vertex: cached boundary walk.
+function LatticeCore.incident(lat::Lattice, ::PlaquetteCenter, ::VertexCenter, i::Int)
+    return copy(_get_cache(lat).plaquettes[i].vertices)
+end
+
+# Bond → Plaquette: cached per-bond list.
+function LatticeCore.incident(lat::Lattice, ::BondCenter, ::PlaquetteCenter, i::Int)
+    cache = _get_cache(lat)
+    b = cache.bonds[i]
+    key = _edge_key(b.i, b.j)
+    return copy(get(cache.plaquettes_by_bond, key, Int[]))
+end
+
+# Plaquette → Bond: walk the plaquette's boundary edges, map each to
+# a bond index via the cache's edge → bond dict.
+function LatticeCore.incident(lat::Lattice, ::PlaquetteCenter, ::BondCenter, i::Int)
+    cache = _get_cache(lat)
+    p = cache.plaquettes[i]
+    vs = p.vertices
+    n = length(vs)
+    out = Int[]
+    for k in 1:n
+        key = _edge_key(vs[k], vs[mod1(k + 1, n)])
+        idx = get(cache.bond_index_of, key, 0)
+        idx == 0 || push!(out, idx)
+    end
+    return out
+end

--- a/src/core/lattice.jl
+++ b/src/core/lattice.jl
@@ -7,11 +7,18 @@ sample, with a `LatticeCore.LatticeBoundary` defining per-axis
 boundary conditions. Subtype of `LatticeCore.AbstractLattice{2, T}`.
 
 The struct stores only the parameters that define the lattice; all
-geometric and connectivity data (`position`, `sublattice`, `neighbors`,
-`bonds`, ...) are derived on demand from the `topology` type parameter
-and the `LatticeCore` interface (`lattice_coord`, `apply_axis_bc`,
-`to_real`). This mirrors the reference `SimpleSquareLattice` in
-LatticeCore and keeps the type lightweight.
+pure-function-of-input data (`position`, `sublattice`, `neighbors`,
+`basis_vectors`, ...) are derived on demand through the LatticeCore
+interface (`lattice_coord`, `apply_axis_bc`, `to_real`). This mirrors
+the reference `SimpleSquareLattice` in LatticeCore and keeps the type
+lightweight.
+
+Boundary-condition-dependent aggregates that appear repeatedly
+(`bonds`, `plaquettes`, the bond and plaquette reverse-lookup tables)
+are memoised through a lazy `cache` field — populated on first access
+by [`_get_cache`](@ref) and then reused by the O(local) element-center
+and incidence overrides. The cache is stored in a `Ref` so the struct
+itself remains immutable.
 
 Type parameters
 
@@ -35,6 +42,11 @@ struct Lattice{
     boundary::B
     indexing::I
     layout::L
+    # Lazy cache for bonds / plaquettes / reverse-lookup tables.
+    # Stored as Ref{Any} because `LatticeCache{T}` isn't defined at
+    # this include point; the getter `_get_cache(lat)` re-asserts the
+    # concrete type. See `core/cache.jl`.
+    cache::Base.RefValue{Any}
 end
 
 # ---- Internal helpers -----------------------------------------------
@@ -253,21 +265,11 @@ function LatticeCore.neighbor_bonds(lat::Lattice{Topo,T}, i::Int) where {Topo,T}
     return out
 end
 
-function LatticeCore.bonds(lat::Lattice)
-    return (b for i in 1:num_sites(lat) for b in neighbor_bonds(lat, i) if b.j > b.i)
-end
-
-# ---- Plaquette enumeration ------------------------------------------
-#
-# Walks `(cell_x, cell_y, kind)` for every PlaquetteRule declared on
-# the topology, applies per-axis BCs to each corner, drops any
-# plaquette whose corners aren't all valid, and materialises the
-# result as a `Plaquette{2, T}` with its boundary vertex indices,
-# centroid and type tag.
-
-function LatticeCore.plaquettes(lat::Lattice{Topo,T}) where {Topo,T}
-    return _materialise_plaquettes(lat)
-end
+# `bonds(lat)` and `plaquettes(lat)` for `Lattice` live in
+# `core/element_api.jl` where they pull from the lazy
+# [`LatticeCache`](@ref) built by [`_get_cache`](@ref). The
+# underlying materialiser for plaquettes stays here because the
+# cache builder needs it in its include-order position.
 
 function _materialise_plaquettes(lat::Lattice{Topo,T}) where {Topo,T}
     Lx, Ly = _dims(lat)
@@ -317,35 +319,9 @@ function _materialise_plaquettes(lat::Lattice{Topo,T}) where {Topo,T}
     return out
 end
 
-# Override `num_elements(::PlaquetteCenter)` so we never materialise
-# the whole list just to count — O(Lx*Ly) scan that skips rejected
-# corners by BC.
-function LatticeCore.num_elements(lat::Lattice{Topo}, ::PlaquetteCenter) where {Topo}
-    Lx, Ly = _dims(lat)
-    uc = get_unit_cell(Topo)
-    isempty(uc.plaquettes) && return 0
-    bx, by = lat.boundary.axes
-    count = 0
-    for cy in 1:Ly, cx in 1:Lx
-        for rule in uc.plaquettes
-            all_valid = true
-            for (_, dx, dy) in rule.corners
-                _, ok_x = apply_axis_bc(bx, cx + dx, Lx)
-                if !ok_x
-                    all_valid = false
-                    break
-                end
-                _, ok_y = apply_axis_bc(by, cy + dy, Ly)
-                if !ok_y
-                    all_valid = false
-                    break
-                end
-            end
-            all_valid && (count += 1)
-        end
-    end
-    return count
-end
+# `num_elements(::Lattice, ::PlaquetteCenter)` and the rest of the
+# element-center / incidence API for `Lattice` live in
+# `core/element_api.jl`, powered by the cached plaquette vector.
 
 # ---- Graph / topology traits ----------------------------------------
 

--- a/test/core/test_element_cache.jl
+++ b/test/core/test_element_cache.jl
@@ -1,0 +1,151 @@
+@testset "Lattice cache + O(local) element_api" begin
+    @testset "cached bonds / plaquettes are stable across repeated calls" begin
+        lat = build_lattice(Square, 5, 5)
+        # Fresh cache on first access.
+        b1 = bonds(lat)
+        b2 = bonds(lat)
+        @test b1 === b2                                  # same Vector object
+        @test b1 == collect(b for i in 1:num_sites(lat) for b in neighbor_bonds(lat, i) if b.j > b.i)
+
+        p1 = plaquettes(lat)
+        p2 = plaquettes(lat)
+        @test p1 === p2
+    end
+
+    @testset "num_elements via cache agrees with declared plaquette counts" begin
+        for (Topo, per_cell) in (
+            (Square, 1),
+            (Triangular, 2),
+            (Honeycomb, 1),
+            (Kagome, 3),
+            (Lieb, 1),
+            (ShastrySutherland, 4),
+            (UnionJack, 4),
+        )
+            lat = build_lattice(Topo, 4, 4)
+            @test num_elements(lat, PlaquetteCenter()) == per_cell * 16
+        end
+
+        # Dice still has no rules → empty cache bucket → 0.
+        @test num_elements(build_lattice(Dice, 3, 3), PlaquetteCenter()) == 0
+    end
+
+    @testset "element_position(BondCenter) O(1) matches bond_center" begin
+        lat = build_lattice(Triangular, 4, 4)
+        bs = collect(bonds(lat))
+        for i in 1:length(bs)
+            @test element_position(lat, BondCenter(), i) == bond_center(lat, bs[i])
+        end
+    end
+
+    @testset "element_position(PlaquetteCenter) O(1) matches plaquette.center" begin
+        lat = build_lattice(Honeycomb, 3, 3)
+        ps = collect(plaquettes(lat))
+        for i in 1:length(ps)
+            @test element_position(lat, PlaquetteCenter(), i) == ps[i].center
+        end
+    end
+
+    @testset "element_neighbors(BondCenter) = bonds sharing a vertex" begin
+        lat = build_lattice(Square, 4, 4)
+        bs = collect(bonds(lat))
+        for i in 1:length(bs)
+            nbrs = element_neighbors(lat, BondCenter(), i)
+            b_self = bs[i]
+            for k in nbrs
+                other = bs[k]
+                @test other.i == b_self.i || other.i == b_self.j ||
+                      other.j == b_self.i || other.j == b_self.j
+                @test k != i
+            end
+            # Symmetry: j ∈ neighbors(i) ⇒ i ∈ neighbors(j).
+            for k in nbrs
+                @test i in element_neighbors(lat, BondCenter(), k)
+            end
+        end
+    end
+
+    @testset "element_neighbors(PlaquetteCenter) = dual graph" begin
+        # On a PBC Square sample each unit square shares an edge with
+        # exactly 4 neighbours (left, right, up, down plaquette).
+        lat = build_lattice(Square, 4, 4)
+        @test num_elements(lat, PlaquetteCenter()) == 16
+        for i in 1:16
+            nbrs = element_neighbors(lat, PlaquetteCenter(), i)
+            @test length(nbrs) == 4
+            # Symmetry.
+            for k in nbrs
+                @test i in element_neighbors(lat, PlaquetteCenter(), k)
+            end
+        end
+    end
+
+    @testset "incident: bond ↔ plaquette round-trip on every topology" begin
+        for Topo in (Square, Triangular, Honeycomb, Kagome, Lieb, UnionJack)
+            lat = build_lattice(Topo, 4, 4)
+            np = num_elements(lat, PlaquetteCenter())
+            np == 0 && continue
+            for p_idx in 1:np
+                bond_ids = incident(lat, PlaquetteCenter(), BondCenter(), p_idx)
+                @test !isempty(bond_ids)
+                # Every bond on p's boundary lists p as one of its
+                # bounding plaquettes.
+                for b in bond_ids
+                    @test p_idx in incident(lat, BondCenter(), PlaquetteCenter(), b)
+                end
+            end
+        end
+    end
+
+    @testset "incident: vertex ↔ bond round-trip" begin
+        lat = build_lattice(Kagome, 3, 3)
+        N = num_sites(lat)
+        for i in 1:N
+            bond_ids = incident(lat, VertexCenter(), BondCenter(), i)
+            for b in bond_ids
+                @test i in incident(lat, BondCenter(), VertexCenter(), b)
+            end
+        end
+    end
+
+    @testset "incident: vertex ↔ plaquette round-trip" begin
+        lat = build_lattice(Honeycomb, 4, 4)
+        N = num_sites(lat)
+        for i in 1:N
+            plaq_ids = incident(lat, VertexCenter(), PlaquetteCenter(), i)
+            for p in plaq_ids
+                @test i in incident(lat, PlaquetteCenter(), VertexCenter(), p)
+            end
+        end
+    end
+
+    @testset "incident: same-centring falls through to element_neighbors" begin
+        lat = build_lattice(Square, 4, 4)
+        for i in 1:num_elements(lat, BondCenter())
+            @test incident(lat, BondCenter(), BondCenter(), i) ==
+                element_neighbors(lat, BondCenter(), i)
+        end
+        for i in 1:num_sites(lat)
+            @test incident(lat, VertexCenter(), VertexCenter(), i) ==
+                element_neighbors(lat, VertexCenter(), i)
+        end
+    end
+
+    @testset "cache survives repeated calls without re-materialising" begin
+        # Side-effect check: after the first call, subsequent calls
+        # must return *the same* Vector object (===), not a fresh
+        # materialisation.
+        lat = build_lattice(Kagome, 5, 5)
+        b1 = bonds(lat)
+        p1 = plaquettes(lat)
+        @test b1 === bonds(lat)
+        @test p1 === plaquettes(lat)
+    end
+
+    @testset "distinct Lattice instances hold independent caches" begin
+        lat_a = build_lattice(Square, 4, 4)
+        lat_b = build_lattice(Square, 5, 5)
+        @test bonds(lat_a) !== bonds(lat_b)
+        @test num_elements(lat_a, BondCenter()) != num_elements(lat_b, BondCenter())
+    end
+end

--- a/test/core/test_element_cache.jl
+++ b/test/core/test_element_cache.jl
@@ -5,7 +5,9 @@
         b1 = bonds(lat)
         b2 = bonds(lat)
         @test b1 === b2                                  # same Vector object
-        @test b1 == collect(b for i in 1:num_sites(lat) for b in neighbor_bonds(lat, i) if b.j > b.i)
+        @test b1 == collect(
+            b for i in 1:num_sites(lat) for b in neighbor_bonds(lat, i) if b.j > b.i
+        )
 
         p1 = plaquettes(lat)
         p2 = plaquettes(lat)
@@ -54,8 +56,10 @@
             b_self = bs[i]
             for k in nbrs
                 other = bs[k]
-                @test other.i == b_self.i || other.i == b_self.j ||
-                      other.j == b_self.i || other.j == b_self.j
+                @test other.i == b_self.i ||
+                    other.i == b_self.j ||
+                    other.j == b_self.i ||
+                    other.j == b_self.j
                 @test k != i
             end
             # Symmetry: j ∈ neighbors(i) ⇒ i ∈ neighbors(j).


### PR DESCRIPTION
## Summary

Iteration 7. Adds a **lazy per-sample cache** on `Lattice` backed by a single `Ref` field, so the element-center and incidence API no longer pays `O(num_bonds)` per call. First access to `bonds` / `plaquettes` / any element-center entry point populates:

- `bonds::Vector{Bond{2, T}}`
- `plaquettes::Vector{Plaquette{2, T}}`
- `bond_index_of::Dict{(min, max), Int}` — endpoint pair → bond index
- `plaquettes_by_vertex::Vector{Vector{Int}}` — per-site plaquette list
- `plaquettes_by_bond::Dict{(min, max), Vector{Int}}` — per-bond list

Subsequent calls are **O(local)**. The struct itself stays immutable — mutation lives entirely inside the `Ref` content.

### Complexity impact

| API | default | specialised |
| --- | --- | --- |
| `element_position(BondCenter, i)` | O(B) | **O(1)** |
| `element_position(PlaquetteCenter, i)` | O(P) | **O(1)** |
| `element_neighbors(BondCenter, i)` | O(B) | **O(degree)** |
| `element_neighbors(PlaquetteCenter, i)` | O(P²) | **O(boundary_len)** |
| `incident(V, B, i)` | O(B) | **O(degree)** |
| `incident(B, V, i)` | O(B) | **O(1)** |
| `incident(V, P, i)` | O(P) | **O(local)** |
| `incident(P, V, i)` | O(P) | **O(1)** |
| `incident(B, P, i)` | O(P·len) | **O(local)** |
| `incident(P, B, i)` | O(P·B) | **O(boundary_len)** |

First-access cost is `O(num_bonds + Σ plaquette_len)`, amortised across all subsequent calls.

### File layout

- **`core/cache.jl`** (new) — `LatticeCache{T}` struct + `_build_lattice_cache` + `_get_cache`
- **`core/element_api.jl`** (new) — specialised `bonds` / `plaquettes` / `num_elements` / `elements` / `element_position` / `element_neighbors` / `incident` methods on `::Lattice`
- **`core/lattice.jl`** — keeps `_materialise_plaquettes` (used by the cache builder) but drops the now-overridden `bonds` / `plaquettes` / `num_elements(::PlaquetteCenter)` methods

`Lattice` gains one new field `cache::Base.RefValue{Any}`, initialised to `Ref{Any}(nothing)` in `build_lattice`. The getter re-asserts the concrete `LatticeCache{T}` type on retrieval.

### Test plan

New `test/core/test_element_cache.jl` covers:
- `bonds` / `plaquettes` return the **same Vector object (`===`)** across repeated calls
- Cached `num_elements` matches the declared per-cell plaquette counts for every wired topology
- `element_position(BondCenter, i)` equals `bond_center(lat, bonds(lat)[i])`
- `element_position(PlaquetteCenter, i)` equals `plaquettes(lat)[i].center`
- `element_neighbors(BondCenter, i)` returns the line graph (verified by endpoint sharing + symmetry)
- `element_neighbors(PlaquetteCenter, i)` returns the dual graph (4 neighbours per unit square on Square PBC, symmetric)
- `incident` **round-trips** on every (V↔B), (V↔P), (B↔P) pair for every topology that declares plaquettes
- Same-centring `incident(E(), E(), i)` falls through to `element_neighbors`
- Two different `Lattice` instances hold **independent** caches (no global state)

### Microbenchmarks (Square 20×20, 400 sites, 800 bonds, 400 plaquettes)

| call | per-call time |
| --- | --- |
| `element_position(BondCenter, i)` | ~0.9 µs |
| `element_neighbors(PlaquetteCenter, i)` | ~1.8 µs |
| `incident(PlaquetteCenter, BondCenter, 1)` | ~28 µs |

- [x] `Pkg.test()` — **3344 / 3344 pass** (was 1403, +1941 new assertions from the round-trip loops)

Bumps version 0.2.6 → **0.2.7**.

## Type of Change

- [x] ✨ **Feature** (`enhancement`) — non-breaking performance + API extension
- [ ] 🐛 **Bug Fix** (`bug`)
- [x] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)