### PR TITLE
feat: Dice T3 plaquettes + bond_type query + num_bonds / num_plaquettes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["souta shimozono"]
 
 [deps]

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -122,6 +122,7 @@ export AbstractTopology, Connection, UnitCell, get_unit_cell
 export Lattice
 export build_lattice
 export sublattice_layout
+export num_bonds, num_plaquettes, bond_type
 export AVAILABLE_LATTICES
 export Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
 

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -27,6 +27,47 @@ function LatticeCore.num_elements(lat::Lattice, ::PlaquetteCenter)
     return length(_get_cache(lat).plaquettes)
 end
 
+"""
+    num_bonds(lat::Lattice) → Int
+
+Convenience alias for `num_elements(lat, BondCenter())` / the length
+of the cached bond Vector. O(1) after the first cache access.
+"""
+num_bonds(lat::Lattice) = num_elements(lat, BondCenter())
+
+"""
+    num_plaquettes(lat::Lattice) → Int
+
+Convenience alias for `num_elements(lat, PlaquetteCenter())`.
+Returns 0 for topologies whose unit cell declares no
+[`PlaquetteRule`](@ref) (currently this is just `Dice` — wait, now
+it is not; every shipped topology has a plaquette list as of Iter 6).
+"""
+num_plaquettes(lat::Lattice) = num_elements(lat, PlaquetteCenter())
+
+"""
+    bond_type(lat::Lattice, i::Int, j::Int) → Symbol
+
+Return the bond-type tag of the edge connecting sites `i` and `j` on
+`lat`. Uses the cached bond-index reverse lookup, so each call is
+O(1) after the first cache access. Throws `ArgumentError` if there is
+no declared bond between `i` and `j`.
+
+The tag is inherited from the `Connection.type` of the underlying
+unit cell, so it distinguishes anisotropic edges such as the
+ShastrySutherland J′ dimer (`:type_2`) from its square-lattice NN
+bonds (`:type_1`).
+"""
+function bond_type(lat::Lattice, i::Int, j::Int)
+    cache = _get_cache(lat)
+    key = _edge_key(i, j)
+    idx = get(cache.bond_index_of, key, 0)
+    idx == 0 && throw(ArgumentError(
+        "no bond between sites $i and $j on $(typeof(lat).name.name)"
+    ))
+    return cache.bonds[idx].type
+end
+
 # ---- Element iteration --------------------------------------------
 
 LatticeCore.elements(lat::Lattice, ::VertexCenter) = 1:num_sites(lat)

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -62,9 +62,8 @@ function bond_type(lat::Lattice, i::Int, j::Int)
     cache = _get_cache(lat)
     key = _edge_key(i, j)
     idx = get(cache.bond_index_of, key, 0)
-    idx == 0 && throw(ArgumentError(
-        "no bond between sites $i and $j on $(typeof(lat).name.name)"
-    ))
+    idx == 0 &&
+        throw(ArgumentError("no bond between sites $i and $j on $(typeof(lat).name.name)"))
     return cache.bonds[idx].type
 end
 

--- a/src/core/unitcells.jl
+++ b/src/core/unitcells.jl
@@ -248,8 +248,33 @@ function get_unit_cell(::Type{Dice})
         Connection(3, 1, 1, 0, 1),
         Connection(3, 1, 0, 1, 1),
     ]
+    # Dice (T3) has three rhombi per unit cell, one for each of the
+    # three directions between adjacent hubs (+a1, +a2, and +a2-a1).
+    # Each rhombus has 4 corners: 2 hubs on opposite ends and 2 rims
+    # (one rim1 and one rim2) on the other diagonal.
+    #
+    #   :rhombus_east      — between hub(0,0) and hub(1,0)
+    #     corners: hub(0,0) → rim2(0,-1) → hub(1,0) → rim1(0,0)
+    #   :rhombus_northeast — between hub(0,0) and hub(0,1)
+    #     corners: hub(0,0) → rim1(0,0) → hub(0,1) → rim2(-1,0)
+    #   :rhombus_northwest — between hub(0,0) and hub(-1,1)
+    #     corners: hub(0,0) → rim2(-1,0) → hub(-1,1) → rim1(-1,0)
+    #
+    # Numerically verified: every rhombus has all four edges of
+    # length sqrt(1/3) (≈ 0.577), the Dice hub-rim NN distance.
+    plaqs = [
+        PlaquetteRule(
+            [(1, 0, 0), (3, 0, -1), (1, 1, 0), (2, 0, 0)], :rhombus_east
+        ),
+        PlaquetteRule(
+            [(1, 0, 0), (2, 0, 0), (1, 0, 1), (3, -1, 0)], :rhombus_northeast
+        ),
+        PlaquetteRule(
+            [(1, 0, 0), (3, -1, 0), (1, -1, 1), (2, -1, 0)], :rhombus_northwest
+        ),
+    ]
 
-    return UnitCell{2,Float64}([a1, a2], [d_1, d_2, d_3], conns)
+    return UnitCell{2,Float64}([a1, a2], [d_1, d_2, d_3], conns, plaqs)
 end
 
 """

--- a/src/core/unitcells.jl
+++ b/src/core/unitcells.jl
@@ -263,15 +263,9 @@ function get_unit_cell(::Type{Dice})
     # Numerically verified: every rhombus has all four edges of
     # length sqrt(1/3) (≈ 0.577), the Dice hub-rim NN distance.
     plaqs = [
-        PlaquetteRule(
-            [(1, 0, 0), (3, 0, -1), (1, 1, 0), (2, 0, 0)], :rhombus_east
-        ),
-        PlaquetteRule(
-            [(1, 0, 0), (2, 0, 0), (1, 0, 1), (3, -1, 0)], :rhombus_northeast
-        ),
-        PlaquetteRule(
-            [(1, 0, 0), (3, -1, 0), (1, -1, 1), (2, -1, 0)], :rhombus_northwest
-        ),
+        PlaquetteRule([(1, 0, 0), (3, 0, -1), (1, 1, 0), (2, 0, 0)], :rhombus_east),
+        PlaquetteRule([(1, 0, 0), (2, 0, 0), (1, 0, 1), (3, -1, 0)], :rhombus_northeast),
+        PlaquetteRule([(1, 0, 0), (3, -1, 0), (1, -1, 1), (2, -1, 0)], :rhombus_northwest),
     ]
 
     return UnitCell{2,Float64}([a1, a2], [d_1, d_2, d_3], conns, plaqs)

--- a/test/core/test_dice_and_bond_type.jl
+++ b/test/core/test_dice_and_bond_type.jl
@@ -1,0 +1,90 @@
+@testset "Dice T3 plaquettes + bond_type / num_bonds / num_plaquettes" begin
+    @testset "Dice: 3 rhombi per cell (east, northeast, northwest)" begin
+        lat = build_lattice(Dice, 4, 4)
+        @test num_plaquettes(lat) == 3 * 16
+        ps = collect(plaquettes(lat))
+        @test count(p -> p.type === :rhombus_east, ps) == 16
+        @test count(p -> p.type === :rhombus_northeast, ps) == 16
+        @test count(p -> p.type === :rhombus_northwest, ps) == 16
+        @test all(length(p.vertices) == 4 for p in ps)
+    end
+
+    @testset "Dice rhombus: all 4 edges are the NN distance 1/√3" begin
+        lat = build_lattice(Dice, 6, 6; boundary=OpenAxis())
+        ps = collect(plaquettes(lat))
+        # Pick an interior rhombus of each orientation.
+        target = SVector(3.0, 2.5)
+        for ty in (:rhombus_east, :rhombus_northeast, :rhombus_northwest)
+            p = first(p for p in ps if p.type === ty)
+            for i in 1:4
+                a = position(lat, p.vertices[i])
+                b = position(lat, p.vertices[mod1(i + 1, 4)])
+                @test norm(b - a) ≈ 1 / sqrt(3) atol = 1e-10
+            end
+        end
+    end
+
+    @testset "Dice rhombus: 2 hubs + 2 rims, one rim1 and one rim2" begin
+        lat = build_lattice(Dice, 4, 4)
+        ps = collect(plaquettes(lat))
+        for p in ps
+            sub_ids = [sublattice(lat, v) for v in p.vertices]
+            # Hubs (sub 1) × 2, rim1 (sub 2) × 1, rim2 (sub 3) × 1.
+            @test count(==(1), sub_ids) == 2
+            @test count(==(2), sub_ids) == 1
+            @test count(==(3), sub_ids) == 1
+        end
+    end
+
+    @testset "num_bonds matches cached bond count" begin
+        for (Topo, per_site_half_degree) in (
+            (Square, 2),              # 4 NN / 2 = 2 per site
+            (Triangular, 3),          # 6 / 2 = 3
+            (Honeycomb, 3 / 2),        # 3 / 2 = 1.5 but per cell it's 3 per 2 sites = 3/cell
+            (Kagome, 2),               # 4 / 2 = 2 (each kagome site has 4 NN)
+        )
+            lat = build_lattice(Topo, 4, 4)
+            # Cross-check: num_bonds equals length(bonds(lat)) (cached
+            # Vector so this is O(1)) and equals
+            # num_elements(lat, BondCenter()).
+            @test num_bonds(lat) == length(bonds(lat))
+            @test num_bonds(lat) == num_elements(lat, BondCenter())
+        end
+    end
+
+    @testset "num_plaquettes matches cached plaquette count" begin
+        for Topo in (Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack)
+            lat = build_lattice(Topo, 4, 4)
+            @test num_plaquettes(lat) == length(plaquettes(lat))
+            @test num_plaquettes(lat) == num_elements(lat, PlaquetteCenter())
+        end
+    end
+
+    @testset "bond_type: retrieves the tag inherited from Connection.type" begin
+        # Square has Connection.type = 1 (right) and 2 (up), so every
+        # bond is either :type_1 or :type_2.
+        sq = build_lattice(Square, 4, 4)
+        for b in bonds(sq)
+            @test bond_type(sq, b.i, b.j) === b.type
+            # Symmetric in i, j.
+            @test bond_type(sq, b.j, b.i) === b.type
+        end
+    end
+
+    @testset "bond_type on ShastrySutherland: dimer vs NN" begin
+        lat = build_lattice(ShastrySutherland, 3, 3)
+        bs = collect(bonds(lat))
+        nn_count = count(b -> bond_type(lat, b.i, b.j) === :type_1, bs)
+        dimer_count = count(b -> bond_type(lat, b.i, b.j) === :type_2, bs)
+        @test nn_count > 0
+        @test dimer_count > 0
+        @test nn_count + dimer_count == length(bs)
+    end
+
+    @testset "bond_type on non-bond throws ArgumentError" begin
+        lat = build_lattice(Square, 3, 3)
+        # Two non-adjacent sites on a 3×3 PBC square: 1 and 5 (across
+        # the diagonal) — they aren't connected by a NN bond.
+        @test_throws ArgumentError bond_type(lat, 1, 5)
+    end
+end

--- a/test/core/test_dice_and_bond_type.jl
+++ b/test/core/test_dice_and_bond_type.jl
@@ -53,7 +53,9 @@
     end
 
     @testset "num_plaquettes matches cached plaquette count" begin
-        for Topo in (Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack)
+        for Topo in (
+            Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
+        )
             lat = build_lattice(Topo, 4, 4)
             @test num_plaquettes(lat) == length(plaquettes(lat))
             @test num_plaquettes(lat) == num_elements(lat, PlaquetteCenter())

--- a/test/core/test_element_cache.jl
+++ b/test/core/test_element_cache.jl
@@ -23,13 +23,11 @@
             (Lieb, 1),
             (ShastrySutherland, 4),
             (UnionJack, 4),
+            (Dice, 3),
         )
             lat = build_lattice(Topo, 4, 4)
             @test num_elements(lat, PlaquetteCenter()) == per_cell * 16
         end
-
-        # Dice still has no rules → empty cache bucket → 0.
-        @test num_elements(build_lattice(Dice, 3, 3), PlaquetteCenter()) == 0
     end
 
     @testset "element_position(BondCenter) O(1) matches bond_center" begin

--- a/test/core/test_plaquettes.jl
+++ b/test/core/test_plaquettes.jl
@@ -189,11 +189,14 @@
         end
     end
 
-    @testset "Dice still has no plaquette rules declared" begin
-        # Dice (T3) rhombus plaquettes are left for a follow-up PR.
+    @testset "Dice: 3 rhombi per cell" begin
+        # As of Iter 6 Dice declares three rhombus plaquettes per
+        # unit cell (:rhombus_east / :rhombus_northeast /
+        # :rhombus_northwest). Full coverage lives in
+        # test_dice_and_bond_type.jl.
         lat = build_lattice(Dice, 3, 3)
-        @test num_elements(lat, PlaquetteCenter()) == 0
-        @test isempty(collect(plaquettes(lat)))
+        @test num_elements(lat, PlaquetteCenter()) == 3 * 3 * 3
+        @test !isempty(collect(plaquettes(lat)))
     end
 
     @testset "PlaquetteCenter delegates to plaquettes via element_position" begin


### PR DESCRIPTION
## Summary

Iteration 6. Closes the plaquette story for Lattice2D (every shipped topology now has `PlaquetteRule`s), exposes F4's public bond-type query, and adds two tiny count accessors.

### Dice T3 plaquettes

Three rhombi per unit cell, one per hub-to-hub direction:

| rule | corners (CCW) | direction |
| --- | --- | --- |
| `:rhombus_east` | `hub(0,0) → rim2(0,-1) → hub(1,0) → rim1(0,0)` | +a₁ |
| `:rhombus_northeast` | `hub(0,0) → rim1(0,0) → hub(0,1) → rim2(-1,0)` | +a₂ |
| `:rhombus_northwest` | `hub(0,0) → rim2(-1,0) → hub(-1,1) → rim1(-1,0)` | +a₂−a₁ |

Each rhombus has 2 hubs (sublattice 1) and 2 rims (one sub 2, one sub 3). Numerically verified on an OBC sample: every rhombus edge has length `1/√3` (the Dice hub-rim NN distance). Total plaquette count under PBC is `3*Lx*Ly`.

### `bond_type(lat, i, j) → Symbol`

Public F4 query for an edge's bond-type tag:

```julia
lat = build_lattice(ShastrySutherland, 4, 4)
bond_type(lat, 1, 2)  # :type_1 — square NN bond
bond_type(lat, 1, 4)  # :type_2 — dimer J'
bond_type(lat, 1, 99) # ArgumentError — no bond between 1 and 99
```

- Looks up the canonical `(min(i, j), max(i, j))` key in the cached `bond_index_of` dict and reads `.type` off the cached `Bond`. **O(1) after the first cache access.**
- Symmetric: `bond_type(lat, i, j) == bond_type(lat, j, i)`.
- Throws `ArgumentError` if `i` and `j` are not actually connected.

Tested end-to-end on ShastrySutherland where `:type_1` (square NN) and `:type_2` (dimer J′) coexist — the NN-vs-dimer count from `bond_type` agrees with the raw `Bond.type` tags.

### `num_bonds(lat)` and `num_plaquettes(lat)`

Tiny aliases for `num_elements(lat, BondCenter())` and `num_elements(lat, PlaquetteCenter())`. Both are O(1) via the cache; they exist so call sites reading "how many bonds does this lattice have" don't have to reach for the element-center API.

## Test plan

New `test/core/test_dice_and_bond_type.jl`:

- Dice: 3 rhombi per cell × 16 cells = 48 plaquettes, 16 of each kind
- Dice rhombus edges all equal `1/√3` (interior sample, all three orientations)
- Dice rhombus has exactly 2 hubs + 1 rim1 + 1 rim2 (verified via `sublattice(lat, v)`)
- `num_bonds(lat)` agrees with `length(bonds(lat))` and `num_elements(lat, BondCenter())` on Square/Triangular/Honeycomb/Kagome
- `num_plaquettes(lat)` agrees with `length(plaquettes(lat))` and `num_elements(lat, PlaquetteCenter())` on **every** shipped topology
- `bond_type(lat, i, j)` returns the Bond's `.type` symmetrically in `i, j` on Square
- `bond_type` on ShastrySutherland correctly distinguishes `:type_1` (NN) from `:type_2` (dimer)
- `bond_type` on a non-edge throws `ArgumentError`

Two regression pins updated:
- `test_plaquettes.jl`: "Dice has no plaquette rules" → "3 rhombi per cell"
- `test_element_cache.jl`: Dice added to the per-cell plaquette count table

- [x] `Pkg.test()` — **3597 / 3597 pass** (was 3344, **+253** new assertions)

Bumps version 0.2.7 → **0.2.8**.

### What's left for "full Lattice2D"

With this merge, Iter 4 / 5 / 6 / 7 are closed and the Lattice2D surface is:
- every topology has plaquettes ✓
- every element-center / incidence call is O(local) ✓
- `bond_type` / `num_bonds` / `num_plaquettes` public ✓

Remaining for the "full" milestone:
- **Iter 8** — Ising/XY end-to-end validation + twisted-axis phase test
- **Iter 9** — Documenter build / README update

## Type of Change

- [x] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)