### PR TITLE
fix: loosen [compat] lower bounds (v0.2.9)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.2.8"
+version = "0.2.9"
 authors = ["souta shimozono"]
 
 [deps]
@@ -10,11 +10,11 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-LatticeCore = "0.8.4"
-LinearAlgebra = "1"
+LatticeCore = "0.8"
+LinearAlgebra = "1.10"
 Plots = "1"
 StaticArrays = "1"
-julia = "1.11"
+julia = "1.10"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
Closes #39

下限を緩めて CompatHelper / registry に優しい設定に。
- LatticeCore: 0.8.4 -> 0.8
- LinearAlgebra: 1 -> 1.10
- julia: 1.11 -> 1.10

patch bump 0.2.8 -> 0.2.9