### PR TITLE
perf: cache basis_sv/sub_offsets and bound shell-neighbor window

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["souta shimozono"]
 
 [deps]

--- a/src/core/lattice.jl
+++ b/src/core/lattice.jl
@@ -54,16 +54,37 @@ end
 
 @inline _dims(lat::Lattice) = (lat.Lx, lat.Ly)
 
-@inline function _basis_sv(::Type{<:Lattice{Topo,T}}) where {Topo,T}
+# Type-level memoization for unit-cell-derived geometric data. Keyed
+# by the `Lattice{Topo,T}` *type* (not instance) — values are pure
+# functions of `(Topo, T)`, so the cache is sound for the lifetime of
+# the session. Built once per `(Topo, T)` pair and reused on every
+# `_basis_sv` / `_sub_offsets` call so hot paths
+# (`_connection_steps_kernel`, `_neighbors_by_shell_kernel`,
+# `_materialise_plaquettes_kernel`, `to_real`, `basis_vectors`) avoid
+# repeated `get_unit_cell` → `SVector` materialisation. See issue #46.
+const _BASIS_SV_CACHE = IdDict{DataType,Any}()
+const _SUB_OFFSETS_CACHE = IdDict{DataType,Any}()
+
+@inline function _basis_sv(::Type{L}) where {Topo,T,L<:Lattice{Topo,T}}
+    K = Lattice{Topo,T}
+    cached = get(_BASIS_SV_CACHE, K, nothing)
+    cached === nothing || return cached::Tuple{SVector{2,T},SVector{2,T}}
     uc = get_unit_cell(Topo)
     a1 = SVector{2,T}(T(uc.basis[1][1]), T(uc.basis[1][2]))
     a2 = SVector{2,T}(T(uc.basis[2][1]), T(uc.basis[2][2]))
-    return a1, a2
+    val = (a1, a2)
+    _BASIS_SV_CACHE[K] = val
+    return val
 end
 
-@inline function _sub_offsets(::Type{<:Lattice{Topo,T}}) where {Topo,T}
+@inline function _sub_offsets(::Type{L}) where {Topo,T,L<:Lattice{Topo,T}}
+    K = Lattice{Topo,T}
+    cached = get(_SUB_OFFSETS_CACHE, K, nothing)
+    cached === nothing || return cached::Vector{SVector{2,T}}
     uc = get_unit_cell(Topo)
-    return [SVector{2,T}(T(p[1]), T(p[2])) for p in uc.sublattice_positions]
+    val = SVector{2,T}[SVector{2,T}(T(p[1]), T(p[2])) for p in uc.sublattice_positions]
+    _SUB_OFFSETS_CACHE[K] = val
+    return val
 end
 
 # ---- LatticeCore required interface ---------------------------------
@@ -243,9 +264,24 @@ function LatticeCore.neighbors(lat::Lattice, i::Int; shell::Union{Nothing,Int}=n
     end
 end
 
-# Compute geometric k-th shell neighbours by scanning a full
-# `(−Lx, Lx) × (−Ly, Ly)` window of unit-cell displacements, filtering
-# candidates through the axis BCs and ranking unique distances.
+# Per-axis window radius for the geometric shell search. Combines two
+# upper bounds:
+#   * a topology-agnostic shell bound `2k+3` (k-th shell of any
+#     supported Bravais topology fits inside `(2k+1)²` cells; +2 pad)
+#   * the BC-imposed reach: `L−1` for OBC, `L÷2` for periodic axes
+# Returns the *smaller* of the two — anything beyond is either
+# unreachable or has a closer minimum-image representative already in
+# the window.
+@inline function _shell_window(ax, L::Int, k::Int)
+    bc_bound = ax isa OpenAxis ? (L - 1) : (L ÷ 2)
+    shell_bound = 2k + 3
+    return max(0, min(bc_bound, shell_bound))
+end
+
+# Compute geometric k-th shell neighbours by scanning a bounded
+# `(−rx, rx) × (−ry, ry)` window of unit-cell displacements (see
+# `_shell_window`), filtering candidates through the axis BCs and
+# ranking unique distances. Issue #47.
 function _neighbors_by_shell(lat::Lattice{Topo,T}, i::Int, k::Int) where {Topo,T}
     bx, by = lat.boundary.axes
     return _neighbors_by_shell_kernel(
@@ -267,7 +303,25 @@ function _neighbors_by_shell_kernel(
     # site j from site i across all unwrapped (dx, dy, sub') candidates.
     dist_map = Dict{Int,T}()
 
-    for dy in (-(Ly - 1)):(Ly - 1), dx in (-(Lx - 1)):(Lx - 1), s in 1:nsub
+    # Restrict the unwrapped-displacement window: the original code
+    # scans the full `(−(L−1), L−1)` rectangle in both axes, which is
+    # `O(Lx · Ly)` per site and dominates `_neighbors_by_shell` on
+    # large samples (issue #47). Two observations:
+    #   * Under PBC, any reachable neighbour has a minimum-image
+    #     representative with `|d| ≤ L÷2` per axis.
+    #   * Under OBC, an axis displacement larger than `L−1` is
+    #     unreachable anyway.
+    # On top of that, the `k`-th shell of a 2D Bravais lattice with
+    # well-conditioned basis is always within `2k+1` cells in each
+    # direction (the connection set generates the shell ranking, so
+    # `k` shells fit inside a `(2k+1)×(2k+1)` window for any
+    # supported topology — Square / Triangular / Honeycomb / Kagome /
+    # Lieb / ShastrySutherland / Dice / UnionJack). We pad to
+    # `2k+3` for headroom against float ties at the ring boundary.
+    rx = _shell_window(bx, Lx, k)
+    ry = _shell_window(by, Ly, k)
+
+    for dy in (-ry):ry, dx in (-rx):rx, s in 1:nsub
         tx = cx + dx
         ty = cy + dy
         nx, ok_x = apply_axis_bc(bx, tx, Lx)


### PR DESCRIPTION
## Summary
- Memoise `_basis_sv` / `_sub_offsets` in type-keyed `IdDict`s so the unit-cell-derived `SVector` data is built once per `(Topo, T)` instead of on every hot-path call (`_connection_steps_kernel`, `_materialise_plaquettes_kernel`, `to_real`, `basis_vectors`). No struct/field change.
- Replace the full `(−(L−1), L−1)` window scan in `_neighbors_by_shell_kernel` with a bounded `_shell_window`, taking the smaller of a topology-agnostic shell bound `2k+3` and a BC-imposed reach (`L−1` for OBC, `L÷2` for periodic axes). Equivalent under the minimum-image rule.
- Bumps version to 0.3.1.

Closes #46
Closes #47

Benchmark (Julia 1.12, single core, before / after on the same machine):

| workload | before | after |
| --- | --- | --- |
| `position(i)` × N, 64×64 Honeycomb, 5 reps | 95 ms / 120 MiB | 16 ms / 44 MiB |
| `neighbors(i; shell=1)` ∀ i, 64×64 Square PBC | 2.95 s / 1.87 GiB | 78 ms / 44 MiB |
| `neighbors(i; shell=2)` ∀ i, 32×32 Triangular | 326 ms / 132 MiB | ~28 ms (after compile) / 41 MiB |

Shell-window scan dominates large-sample queries; the bounded window gives ~38× on 64² Square shell=1 with identical results.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` — 3653 / 3653 pass
- [x] Existing `test_shell_neighbors.jl` covers Square / Triangular / Honeycomb / ShastrySutherland shells under PBC and OBC
- [x] Manual spot-check that bounded window returns identical neighbour sets vs. the full-window baseline