### PR TITLE
Batch low: l2d helper docstrings, kwarg UnitCell, edge_key util, README Plots note

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["souta shimozono"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ println("Is bipartite? ", lat.is_bipartite)
 
 ![Honeycomb Lattice](docs/src/assets/figures/lattice/honeycomb_lattice.png)
 
+## Plots dependency
+
+`Lattice2D` re-exports `materialize` and `require_finite` from
+`LatticeCore`. Plotting helpers (e.g. via `Plots.plot(lat)`) are
+provided through `LatticeCore`'s `LatticeCorePlotsExt` package
+extension, which activates only when both `LatticeCore` and `Plots`
+are loaded. As a result:
+
+- A user that only computes neighbours / bonds / plaquettes / momenta
+  does **not** need `Plots` and pays no precompilation cost for it.
+- A user that wants visualisation should `using Plots` alongside
+  `using Lattice2D`; the recipe / plot method is then picked up
+  automatically.
+
+The `docs/` build environment loads `Plots` explicitly so the gallery
+figures are rendered; see `docs/src/Gallery.md` for visualisation
+examples.
+
+> Note: `Project.toml` currently lists `Plots` as a regular dependency
+> for backward compatibility with downstream code that imports it
+> transitively. Migrating it to a `[weakdeps]` extension is tracked
+> separately and will be a breaking release.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to open an Issue or submit a pull requests.

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -107,6 +107,7 @@ import LatticeCore:
 
 # ---- Lattice2D source files -----------------------------------------
 
+include("utils/edge_key.jl")
 include("core/topology.jl")
 include("core/unitcells.jl")
 include("core/lattice.jl")
@@ -118,7 +119,7 @@ include("utils/iterator.jl")
 # ---- Exports --------------------------------------------------------
 
 # Lattice2D-local types and functions
-export AbstractTopology, Connection, UnitCell, get_unit_cell
+export AbstractTopology, Connection, UnitCell, get_unit_cell, get_plaquette_rules
 export Lattice
 export build_lattice
 export sublattice_layout

--- a/src/core/cache.jl
+++ b/src/core/cache.jl
@@ -37,8 +37,6 @@ struct LatticeCache{T<:AbstractFloat}
     plaquettes_by_bond::Dict{Tuple{Int,Int},Vector{Int}}
 end
 
-@inline _edge_key(i::Int, j::Int) = (min(i, j), max(i, j))
-
 """
     _build_lattice_cache(lat::Lattice{Topo, T}) → LatticeCache{T}
 

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -11,6 +11,31 @@ call. Include order-wise this file has to come after `lattice.jl`
 The overrides here replace LatticeCore's correctness-only O(N)
 defaults — the lattice still implements the same contract, callers
 just stop paying O(num_bonds) per element-position lookup.
+
+## Naming convention: element-API vs. Lattice2D helpers
+
+Two coexisting query styles are exposed for bonds and plaquettes:
+
+* **Generic, LatticeCore-owned element API** —
+  `num_elements(lat, BondCenter())`, `element_position(lat, BondCenter(), i)`,
+  `elements(lat, BondCenter())`, `incident(lat, BondCenter(), VertexCenter(), i)`,
+  and so on. These are uniform across centring kinds (`VertexCenter`,
+  `BondCenter`, `PlaquetteCenter`, …) and are what generic algorithms
+  written against the `AbstractLattice` interface should call.
+
+* **Lattice2D-local convenience helpers** — `num_bonds(lat)`,
+  `num_plaquettes(lat)`, `bond_type(lat, i, j)`. These are thin,
+  human-friendly aliases over the element-API methods above; they are
+  exported by `Lattice2D` (not `LatticeCore`) and exist so that
+  hand-written code at the Lattice2D layer can read naturally
+  (`num_bonds(lat)` reads better than
+  `num_elements(lat, BondCenter())` at a call site that only ever
+  cares about bonds).
+
+The two never disagree by construction (`num_bonds` literally calls
+`num_elements(lat, BondCenter())`). A future refactor may move the
+helpers under a sub-namespace to make the distinction more explicit;
+that change is breaking and tracked separately.
 """
 
 # ---- Bond and plaquette enumeration through the cache --------------

--- a/src/core/topology.jl
+++ b/src/core/topology.jl
@@ -82,12 +82,65 @@ function UnitCell{D,T}(
 end
 
 """
+    UnitCell{D, T}(; basis, sublattice_positions, connections, plaquettes = PlaquetteRule[])
+
+Keyword-argument constructor for [`UnitCell`](@ref). Equivalent to the
+positional `UnitCell{D, T}(basis, sublattice_positions, connections, plaquettes)`,
+but lets call sites label each argument explicitly and omit
+`plaquettes` for topologies that don't (yet) declare any.
+
+The 3-positional and 4-positional forms remain available unchanged.
+"""
+function UnitCell{D,T}(;
+    basis::Vector{Vector{T}},
+    sublattice_positions::Vector{Vector{T}},
+    connections::Vector{Connection},
+    plaquettes::Vector{PlaquetteRule}=PlaquetteRule[],
+) where {D,T}
+    return UnitCell{D,T}(basis, sublattice_positions, connections, plaquettes)
+end
+
+"""
     get_unit_cell(::Type{T}) where {T <: AbstractTopology}
 
 Return the [`UnitCell`](@ref) describing topology `T`. Concrete
 topology types (`Square`, `Triangular`, ...) specialise this
 method. The fallback throws.
+
+See also [`get_plaquette_rules`](@ref) for plaquette-only
+introspection.
 """
 function get_unit_cell(::Type{T}) where {T<:AbstractTopology}
     return error("UnitCell not defined for $T")
+end
+
+"""
+    get_plaquette_rules(::Type{T}) where {T <: AbstractTopology}
+        → Vector{PlaquetteRule}
+
+Introspection helper that returns the list of [`PlaquetteRule`](@ref)
+templates declared in topology `T`'s unit cell. Equivalent to
+`get_unit_cell(T).plaquettes`, but communicates intent ("I only want
+the plaquette rules, not the full unit cell") and returns an empty
+`Vector{PlaquetteRule}` for topologies that haven't been wired up to
+the plaquette API yet.
+
+Each `PlaquetteRule` is a *template* on the unit cell: its `corners`
+are `(sublattice, dx, dy)` tuples relative to the reference cell, its
+`type` tags the plaquette kind (e.g. `:square`, `:up_triangle`), and
+`build_lattice` instantiates them into concrete `Plaquette` objects on
+the finite sample. The complementary count on the instantiated lattice
+is [`num_plaquettes`](@ref).
+
+# Example
+
+```julia
+julia> rules = get_plaquette_rules(Square);
+
+julia> length(rules), rules[1].type
+(1, :square)
+```
+"""
+function get_plaquette_rules(::Type{T}) where {T<:AbstractTopology}
+    return get_unit_cell(T).plaquettes
 end

--- a/src/utils/edge_key.jl
+++ b/src/utils/edge_key.jl
@@ -1,0 +1,19 @@
+"""
+    _edge_key(i::Int, j::Int) → Tuple{Int, Int}
+
+Canonical, orientation-independent key for an undirected edge between
+sites `i` and `j`, defined as `(min(i, j), max(i, j))`.
+
+This helper is used by the per-lattice [`LatticeCache`](@ref) and the
+element / incidence API in `core/element_api.jl` to look up bonds and
+plaquette-by-bond entries without caring which endpoint walked first.
+
+It is shared as a single internal utility (rather than re-defined ad
+hoc in each file) so that any future change to the canonical-form
+convention (e.g. promoting it to a struct) only needs to happen here.
+
+This is **internal** to `Lattice2D` — it is not exported and should
+not be relied on by downstream packages. If a similar helper is needed
+in `LatticeCore` itself it should be promoted there in a separate PR.
+"""
+@inline _edge_key(i::Int, j::Int) = (min(i, j), max(i, j))

--- a/test/core/test_plaquette_introspection.jl
+++ b/test/core/test_plaquette_introspection.jl
@@ -1,7 +1,8 @@
 @testset "plaquette introspection helpers" begin
     @testset "get_plaquette_rules ↔ get_unit_cell.plaquettes" begin
-        for Topo in (Square, Triangular, Honeycomb, Kagome, Lieb,
-                     ShastrySutherland, Dice, UnionJack)
+        for Topo in (
+            Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
+        )
             rules = get_plaquette_rules(Topo)
             uc_rules = get_unit_cell(Topo).plaquettes
             @test rules isa Vector{PlaquetteRule}
@@ -37,9 +38,7 @@
 
         # plaquettes default
         uc_kw_default = UnitCell{2,Float64}(;
-            basis=[a1, a2],
-            sublattice_positions=[[0.0, 0.0]],
-            connections=conns,
+            basis=[a1, a2], sublattice_positions=[[0.0, 0.0]], connections=conns
         )
         @test uc_kw_default.plaquettes == PlaquetteRule[]
     end

--- a/test/core/test_plaquette_introspection.jl
+++ b/test/core/test_plaquette_introspection.jl
@@ -1,0 +1,55 @@
+@testset "plaquette introspection helpers" begin
+    @testset "get_plaquette_rules ↔ get_unit_cell.plaquettes" begin
+        for Topo in (Square, Triangular, Honeycomb, Kagome, Lieb,
+                     ShastrySutherland, Dice, UnionJack)
+            rules = get_plaquette_rules(Topo)
+            uc_rules = get_unit_cell(Topo).plaquettes
+            @test rules isa Vector{PlaquetteRule}
+            @test length(rules) == length(uc_rules)
+            for (a, b) in zip(rules, uc_rules)
+                @test a.corners == b.corners
+                @test a.type == b.type
+            end
+        end
+    end
+
+    @testset "kwarg UnitCell constructor matches positional" begin
+        a1 = [1.0, 0.0]
+        a2 = [0.0, 1.0]
+        conns = Connection[Connection(1, 1, 1, 0, 1), Connection(1, 1, 0, 1, 1)]
+        plaqs = PlaquetteRule[PlaquetteRule(
+            [(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)], :square
+        )]
+
+        uc_pos = UnitCell{2,Float64}([a1, a2], [[0.0, 0.0]], conns, plaqs)
+        uc_kw = UnitCell{2,Float64}(;
+            basis=[a1, a2],
+            sublattice_positions=[[0.0, 0.0]],
+            connections=conns,
+            plaquettes=plaqs,
+        )
+        @test uc_pos.basis == uc_kw.basis
+        @test uc_pos.sublattice_positions == uc_kw.sublattice_positions
+        @test length(uc_pos.connections) == length(uc_kw.connections)
+        @test length(uc_pos.plaquettes) == length(uc_kw.plaquettes)
+        @test uc_pos.plaquettes[1].type == uc_kw.plaquettes[1].type
+        @test uc_pos.plaquettes[1].corners == uc_kw.plaquettes[1].corners
+
+        # plaquettes default
+        uc_kw_default = UnitCell{2,Float64}(;
+            basis=[a1, a2],
+            sublattice_positions=[[0.0, 0.0]],
+            connections=conns,
+        )
+        @test uc_kw_default.plaquettes == PlaquetteRule[]
+    end
+
+    @testset "num_bonds / num_elements consistency" begin
+        for Topo in (Square, Honeycomb, Kagome)
+            lat = build_lattice(Topo, 4, 4)
+            @test num_bonds(lat) == num_elements(lat, BondCenter())
+            @test num_plaquettes(lat) == num_elements(lat, PlaquetteCenter())
+            @test length(get_plaquette_rules(Topo)) ≥ 1
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- **#49** Add a docstring at the top of `core/element_api.jl` that lays out the relationship between LatticeCore-owned generic element API (`num_elements`, `element_position`, `elements`, `incident`) and the Lattice2D-local convenience helpers (`num_bonds`, `num_plaquettes`, `bond_type`). Namespace split deferred as a separate breaking change.
- **#50** Add docstring to `UnitCell.plaquettes` field via `UnitCell` docstring; introduce a kwarg `UnitCell{D,T}(; basis, sublattice_positions, connections, plaquettes = PlaquetteRule[])` constructor coexisting with the 3- and 4-arg positional forms; add `get_plaquette_rules(::Type{<:AbstractTopology})` introspection helper (exported).
- **#51** Hoist the `_edge_key(i, j) = (min(i,j), max(i,j))` helper out of `core/cache.jl` into a single shared `src/utils/edge_key.jl` with full docstring; included before any consumer in `Lattice2D.jl`. Internal-only — no LatticeCore promotion this round.
- **#52** No `ext/` directory currently exists; `materialize` / `require_finite` are re-exports from LatticeCore. Added a README section explaining that plot recipes activate via `LatticeCore`'s `LatticeCorePlotsExt` package extension and that `Plots` is currently still a regular dep for backward compat (a `[weakdeps]` migration is breaking and tracked separately).
- Bump version `0.3.1` → `0.3.2`.
- New test file `test/core/test_plaquette_introspection.jl` covers `get_plaquette_rules`, the kwarg `UnitCell` constructor, and `num_bonds` / element-API consistency.

Closes #49
Closes #50
Closes #51
Closes #52

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (3723 / 3723)
- [x] `get_plaquette_rules(Topo)` returns `Vector{PlaquetteRule}` for all shipped topologies and matches `get_unit_cell(Topo).plaquettes` field-wise
- [x] Kwarg `UnitCell{D,T}` constructor produces structurally identical objects to the positional form, with `plaquettes` defaulting to `PlaquetteRule[]`
- [x] No behavioural change to `num_bonds` / `num_elements(lat, BondCenter())` (consistency asserted in new tests)
- [x] `_edge_key` removed from `cache.jl`; all call sites in `cache.jl` and `element_api.jl` resolve through the new shared util