### PR TITLE
test: add Aqua.jl checks and README QA note

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["souta shimozono"]
 
 [deps]
@@ -10,15 +10,19 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+Aqua = "0.8"
 LatticeCore = "0.8"
 LinearAlgebra = "1.10"
 Plots = "1"
+Random = "1.10"
 StaticArrays = "1"
+Test = "1.10"
 julia = "1.10"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Random", "Test"]
+test = ["Aqua", "Random", "Test"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Code Style: Blue](https://img.shields.io/badge/Code%20Style-Blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![codecov](https://codecov.io/gh/sotashimozono/Lattice2D.jl/graph/badge.svg?token=6E7VZ9MJMK)](https://codecov.io/gh/sotashimozono/Lattice2D.jl)
 [![Build Status](https://github.com/sotashimozono/Lattice2D.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/sotashimozono/Lattice2D.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Features
@@ -66,6 +67,13 @@ examples.
 > for backward compatibility with downstream code that imports it
 > transitively. Migrating it to a `[weakdeps]` extension is tracked
 > separately and will be a breaking release.
+
+## Quality assurance
+
+The test suite runs [Aqua.jl](https://github.com/JuliaTesting/Aqua.jl)
+checks (ambiguities / unbound args / undefined exports / stale deps /
+piracy / persistent tasks) on every CI build, with `Plots` excluded from
+`stale_deps` while its migration to `[weakdeps]` is pending.
 
 ## Contributing
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Lattice2D, Test
 using LinearAlgebra
 using Random
 using StaticArrays
+using Aqua
 
 const FIG_BASE = joinpath(pkgdir(Lattice2D), "docs", "src", "assets", "figures")
 const FIG_LAT = joinpath(FIG_BASE, "lattice")
@@ -33,4 +34,26 @@ const dirs = ["core", "lattices", "utils"]
             end
         end
     end
+end
+
+@testset "Aqua" begin
+    # Restrict ambiguity detection to Lattice2D itself so that method
+    # ambiguities living in upstream packages (e.g. LatticeCore, Plots)
+    # do not turn the suite red.
+    #
+    # `Plots` is currently a regular `[deps]` entry for backward
+    # compatibility (see README "Plots dependency"); plotting is in
+    # practice provided through `LatticeCorePlotsExt`. Migrating it to
+    # `[weakdeps]` is tracked separately and will be a breaking release,
+    # so `stale_deps` is configured to ignore `Plots`.
+    Aqua.test_all(
+        Lattice2D;
+        ambiguities=(; broken=false, recursive=false),
+        piracies=true,
+        stale_deps=(; ignore=[:Plots]),
+        deps_compat=true,
+        project_extras=true,
+        unbound_args=true,
+        undefined_exports=true,
+    )
 end


### PR DESCRIPTION
## Summary
- Add `Aqua.test_all(Lattice2D)` to the test suite with non-recursive ambiguity scan and a `Plots`-ignored `stale_deps` (matching the README's backward-compatibility note about `Plots` pending migration to `[weakdeps]`).
- Wire `Aqua` into `[extras]` / `[targets]` and declare compat for `Aqua`, `Random`, and `Test` so `Aqua.test_deps_compat` is satisfied.
- README gets an Aqua QA badge plus a short "Quality assurance" section; `Project.toml` patch-bumped to 0.3.3.

Closes #44

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` — original suite (3723 passes) and Aqua testset (11 passes) both green.
- [ ] CI green on the PR.