### PR TITLE
feat: fill LatticeCore API gap (to_lattice + element overrides)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["souta shimozono"]
 
 [deps]

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -100,6 +100,14 @@ LatticeCore.elements(lat::Lattice, ::PlaquetteCenter) = _get_cache(lat).plaquett
 
 # ---- Element positions: O(1) via cached Vector --------------------
 
+# VertexCenter override: explicit so the call site does not have to
+# round-trip through LatticeCore's generic AbstractLattice fallback
+# (which already calls `position(lat, i)`). The behaviour is the same,
+# this method just makes the element-API contract self-documenting on
+# `Lattice` and matches the issue #42 request for an explicit
+# specialisation.
+LatticeCore.element_position(lat::Lattice, ::VertexCenter, i::Int) = position(lat, i)
+
 function LatticeCore.element_position(lat::Lattice, ::BondCenter, i::Int)
     b = _get_cache(lat).bonds[i]
     return bond_center(lat, b)
@@ -107,6 +115,29 @@ end
 
 function LatticeCore.element_position(lat::Lattice, ::PlaquetteCenter, i::Int)
     return _get_cache(lat).plaquettes[i].center
+end
+
+# ---- Element-position iterators: lazy, no full materialisation ----
+#
+# LatticeCore's generic `element_positions(lat, e)` is a lazy
+# generator over `1:num_elements(lat, e)` that calls
+# `element_position(lat, e, i)` on each step. For `Lattice` we can do
+# better: `BondCenter` and `PlaquetteCenter` already have a cached
+# Vector, so we hand back a generator that indexes the cache directly
+# (no per-step `_nth` walk, no extra dispatch through the generic
+# fallback). For `VertexCenter` we forward to `positions(lat)` so the
+# call shares whatever iteration strategy the lattice picks for sites.
+
+LatticeCore.element_positions(lat::Lattice, ::VertexCenter) = positions(lat)
+
+function LatticeCore.element_positions(lat::Lattice, ::BondCenter)
+    bs = _get_cache(lat).bonds
+    return (bond_center(lat, b) for b in bs)
+end
+
+function LatticeCore.element_positions(lat::Lattice, ::PlaquetteCenter)
+    ps = _get_cache(lat).plaquettes
+    return (p.center for p in ps)
 end
 
 # ---- Same-centring adjacency: O(degree) / O(boundary) -------------

--- a/src/core/lattice.jl
+++ b/src/core/lattice.jl
@@ -514,3 +514,64 @@ function LatticeCore.to_real(lat::Lattice{Topo,T}, coord::LatticeCoord{2}) where
     subs = _sub_offsets(typeof(lat))
     return RealSpace{2,T}((cx - 1) * a1 + (cy - 1) * a2 + subs[s])
 end
+
+"""
+    to_lattice(lat::Lattice, coord::RealSpace) → LatticeCoord{2}
+
+Inverse of [`to_real`](@ref): map a real-space point back to the
+nearest [`LatticeCoord`](@ref) on `lat`. The implementation inverts
+the basis matrix `A = [a1 a2]` once per call (`SMatrix{2,2}`, so the
+inverse is non-allocating), subtracts each candidate sublattice
+offset, and picks the `(cell, sublattice)` triple whose rounded cell
+indices reproduce `coord` with the smallest residual.
+
+For periodic axes the rounded cell is wrapped into `1:Lx` / `1:Ly`
+through `mod1`, so points that lie outside the fundamental domain
+still resolve to a valid in-sample site. For open axes the rounded
+cell is returned as-is even when it falls outside `1:L`; callers that
+need an in-sample guarantee should validate the result against
+`(Lx, Ly)`.
+
+Together with [`to_real`](@ref) this satisfies
+`to_lattice(lat, to_real(lat, c)) == c` for every in-sample
+`LatticeCoord` and every shipped topology.
+"""
+function LatticeCore.to_lattice(lat::Lattice{Topo,T}, coord::RealSpace{2}) where {Topo,T}
+    a1, a2 = _basis_sv(typeof(lat))
+    subs = _sub_offsets(typeof(lat))
+    A = SMatrix{2,2,T}(a1[1], a1[2], a2[1], a2[2])
+    Ainv = inv(A)
+    bx, by = lat.boundary.axes
+
+    best_s = 1
+    best_cell = (1, 1)
+    best_resid = typemax(T)
+    @inbounds for s in eachindex(subs)
+        frac = Ainv * (coord.x - subs[s])
+        # `frac` holds (cx-1, cy-1) in continuous units. Round to the
+        # nearest integer cell, then shift back to 1-based indexing.
+        rx = round(Int, frac[1]) + 1
+        ry = round(Int, frac[2]) + 1
+        # Apply periodic wrap before measuring the residual so that a
+        # point sitting on the +Lx boundary of a PBC sample resolves
+        # to cell 1 instead of cell `Lx + 1`.
+        cx = bx isa OpenAxis ? rx : mod1(rx, lat.Lx)
+        cy = by isa OpenAxis ? ry : mod1(ry, lat.Ly)
+        # The residual we minimise is the in-cell offset between
+        # `coord` and the nearest representative of sublattice `s`.
+        # `frac - round(frac)` gives that offset in lattice-vector
+        # units; multiply by `A` to recover real-space distance, which
+        # makes the comparison invariant under non-orthogonal / scaled
+        # bases. Using the *unwrapped* round avoids paying for the
+        # PBC wrap in the metric — the wrapped cell is only used for
+        # the returned LatticeCoord.
+        offset = SVector{2,T}(frac[1] - (rx - 1), frac[2] - (ry - 1))
+        resid = norm(A * offset)
+        if resid < best_resid
+            best_resid = resid
+            best_s = s
+            best_cell = (cx, cy)
+        end
+    end
+    return LatticeCoord{2}(best_cell, best_s)
+end

--- a/test/core/test_api_gap_lc_impl.jl
+++ b/test/core/test_api_gap_lc_impl.jl
@@ -3,8 +3,9 @@
     # ---- to_lattice (issue #41) ------------------------------------
 
     @testset "to_lattice round-trips with to_real on every shipped topology" begin
-        for Topo in (Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland,
-                     Dice, UnionJack)
+        for Topo in (
+            Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
+        )
             lat = build_lattice(Topo, 4, 4)
             for i in 1:num_sites(lat)
                 r = to_real(lat, lattice_coord(RowMajor(), (4, 4), num_sublattices(lat), i))

--- a/test/core/test_api_gap_lc_impl.jl
+++ b/test/core/test_api_gap_lc_impl.jl
@@ -1,0 +1,115 @@
+@testset "LatticeCore API gap implementations on Lattice" begin
+
+    # ---- to_lattice (issue #41) ------------------------------------
+
+    @testset "to_lattice round-trips with to_real on every shipped topology" begin
+        for Topo in (Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland,
+                     Dice, UnionJack)
+            lat = build_lattice(Topo, 4, 4)
+            for i in 1:num_sites(lat)
+                r = to_real(lat, lattice_coord(RowMajor(), (4, 4), num_sublattices(lat), i))
+                back = to_lattice(lat, r)
+                @test back == lattice_coord(RowMajor(), (4, 4), num_sublattices(lat), i)
+            end
+        end
+    end
+
+    @testset "to_lattice resolves sublattice on Honeycomb" begin
+        lat = build_lattice(Honeycomb, 3, 3)
+        for i in 1:num_sites(lat)
+            p = position(lat, i)
+            lc = to_lattice(lat, RealSpace{2,Float64}(SVector(p[1], p[2])))
+            @test lc.sublattice == sublattice(lat, i)
+        end
+    end
+
+    @testset "to_lattice on a slightly perturbed point still rounds correctly" begin
+        # Each site of a 4 × 4 Square lattice sits on integer coords
+        # (0, 0), (1, 0), .... A small Δ smaller than half the basis
+        # vector must still resolve to the same site.
+        lat = build_lattice(Square, 4, 4)
+        Δ = SVector(0.1, -0.1)
+        for i in 1:num_sites(lat)
+            p = position(lat, i)
+            lc = to_lattice(lat, RealSpace{2,Float64}(p + Δ))
+            i_back = site_index(RowMajor(), (4, 4), 1, lc)
+            @test i_back == i
+        end
+    end
+
+    @testset "to_lattice wraps under PBC, clips to candidate cells under OBC" begin
+        # PBC: a point one full lattice vector to the right of site 1
+        # must land back on site 1's cell because of the wrap.
+        lat_pbc = build_lattice(Square, 4, 4)
+        a1, a2 = basis_vectors(lat_pbc)[:, 1], basis_vectors(lat_pbc)[:, 2]
+        p1 = position(lat_pbc, 1)
+        lc = to_lattice(lat_pbc, RealSpace{2,Float64}(p1 + 4 * a1))
+        @test lc.cell == (1, 1)
+
+        # OBC: same query on an open lattice does NOT wrap — it returns
+        # the nearest unwrapped cell index even though it's out of range.
+        # We only assert that the query does not throw and that the
+        # returned cell agrees with the unwrapped rounding.
+        lat_obc = build_lattice(Square, 4, 4; boundary=OpenAxis())
+        lc_obc = to_lattice(lat_obc, RealSpace{2,Float64}(p1 + 4 * a1))
+        @test lc_obc.cell == (5, 1)
+    end
+
+    @testset "to_lattice(::LatticeCoord) is the identity" begin
+        # Inherited from LatticeCore, but exercise it through Lattice2D.
+        lat = build_lattice(Square, 3, 3)
+        c = LatticeCoord{2}((2, 1), 1)
+        @test to_lattice(lat, c) === c
+    end
+
+    # ---- element_position(::VertexCenter) (issue #42) ---------------
+
+    @testset "element_position(::VertexCenter) matches position(lat, i)" begin
+        for Topo in (Square, Honeycomb, Kagome, Lieb, ShastrySutherland)
+            lat = build_lattice(Topo, 3, 3)
+            for i in 1:num_sites(lat)
+                @test element_position(lat, VertexCenter(), i) == position(lat, i)
+            end
+        end
+    end
+
+    # ---- element_positions specialisations (issue #43) --------------
+
+    @testset "element_positions(::VertexCenter) iterates positions(lat)" begin
+        lat = build_lattice(Square, 4, 3)
+        ps = collect(element_positions(lat, VertexCenter()))
+        @test length(ps) == num_sites(lat)
+        @test ps == collect(positions(lat))
+    end
+
+    @testset "element_positions(::BondCenter) lazy: matches element_position pointwise" begin
+        lat = build_lattice(Triangular, 4, 4)
+        nb = num_elements(lat, BondCenter())
+        ps = collect(element_positions(lat, BondCenter()))
+        @test length(ps) == nb
+        for i in 1:nb
+            @test ps[i] == element_position(lat, BondCenter(), i)
+        end
+    end
+
+    @testset "element_positions(::PlaquetteCenter) lazy: matches plaquette centers" begin
+        lat = build_lattice(Honeycomb, 3, 3)
+        np = num_elements(lat, PlaquetteCenter())
+        ps = collect(element_positions(lat, PlaquetteCenter()))
+        @test length(ps) == np
+        for i in 1:np
+            @test ps[i] == element_position(lat, PlaquetteCenter(), i)
+        end
+    end
+
+    @testset "element_positions does not allocate a Vector{...} eagerly" begin
+        # The specialised methods return generators; they should not
+        # be `<:AbstractVector`. The user-facing contract is
+        # "iterator over positions" — concrete tests for that contract
+        # live above; here we just confirm the specialisation didn't
+        # accidentally regress to eager `collect`.
+        lat = build_lattice(Kagome, 3, 3)
+        @test !(element_positions(lat, BondCenter()) isa AbstractVector)
+        @test !(element_positions(lat, PlaquetteCenter()) isa AbstractVector)
+    end
+end


### PR DESCRIPTION
## Summary
- Implement `to_lattice(::Lattice, ::RealSpace)` by inverting the basis matrix once per call, scanning sublattice candidates, and picking the smallest in-cell residual. PBC axes wrap via `mod1`; OBC axes clip to the nearest unwrapped cell. Round-trips with `to_real` on every shipped topology.
- Specialise `element_position(::Lattice, ::VertexCenter, i)` to forward to `position(lat, i)` so the element-API contract is self-documenting on `Lattice` (no behaviour change vs the LatticeCore default).
- Override `element_positions(::Lattice, e)` for `VertexCenter` / `BondCenter` / `PlaquetteCenter` to hand back lazy generators backed by `positions(lat)` and the bond / plaquette caches — no eager `Vector` materialisation, no per-step `_nth` walk through the generic fallback.
- Patch bump 0.3.3 -> 0.3.4.

Closes #41
Closes #42
Closes #43

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (4244 + 11 Aqua, 0 failures).
- [x] `to_lattice` round-trips with `to_real` over Square / Triangular / Honeycomb / Kagome / Lieb / ShastrySutherland / Dice / UnionJack on a 4x4 sample.
- [x] Sublattice resolution verified on Honeycomb; perturbed-point rounding verified on Square.
- [x] PBC wrap and OBC clip behaviour both covered.
- [x] `element_position(::VertexCenter)` matches `position(lat, i)` across multiple topologies.
- [x] `element_positions` for each centring matches pointwise `element_position` calls and is not eagerly materialised (`!isa AbstractVector`).