### PR TITLE
feat: FFT structure_factor on every Bravais topology

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["souta shimozono"]
 
 [deps]
@@ -9,9 +9,16 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[weakdeps]
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+
+[extensions]
+Lattice2DFFTWExt = "FFTW"
+
 [compat]
 Aqua = "0.8"
-LatticeCore = "0.8"
+FFTW = "1"
+LatticeCore = "0.10.2"
 LinearAlgebra = "1.10"
 Plots = "1"
 Random = "1.10"
@@ -21,8 +28,9 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Random", "Test"]
+test = ["Aqua", "FFTW", "Random", "Test"]

--- a/ext/Lattice2DFFTWExt.jl
+++ b/ext/Lattice2DFFTWExt.jl
@@ -60,15 +60,19 @@ Lattice2DFFTWExt
 # directly — the FFT path for these topologies then reuses
 # `LatticeCoreFFTWExt._structure_factor_fft` unchanged.
 
-LatticeCore._has_known_grid(lat::Lattice2D.Lattice{Lattice2D.Square}) =
+function LatticeCore._has_known_grid(lat::Lattice2D.Lattice{Lattice2D.Square})
     _is_rowmajor_periodic(lat)
-LatticeCore._has_known_grid(lat::Lattice2D.Lattice{Lattice2D.Triangular}) =
+end
+function LatticeCore._has_known_grid(lat::Lattice2D.Lattice{Lattice2D.Triangular})
     _is_rowmajor_periodic(lat)
+end
 
-LatticeCore._reshape_state(::Lattice2D.Lattice{Lattice2D.Square}, state, dims) =
+function LatticeCore._reshape_state(::Lattice2D.Lattice{Lattice2D.Square}, state, dims)
     reshape(state, dims)
-LatticeCore._reshape_state(::Lattice2D.Lattice{Lattice2D.Triangular}, state, dims) =
+end
+function LatticeCore._reshape_state(::Lattice2D.Lattice{Lattice2D.Triangular}, state, dims)
     reshape(state, dims)
+end
 
 # ---- Multi-sublattice override --------------------------------------
 #

--- a/ext/Lattice2DFFTWExt.jl
+++ b/ext/Lattice2DFFTWExt.jl
@@ -1,0 +1,227 @@
+module Lattice2DFFTWExt
+
+using Lattice2D
+using LatticeCore
+using FFTW
+using StaticArrays
+using LinearAlgebra
+
+"""
+    Lattice2DFFTWExt
+
+Optional `Lattice2D` extension that opts the package's `Lattice{Topo,T}`
+topologies into the FFT-based fast path of
+`structure_factor(lat, state, ml)`.
+
+Loaded automatically once the user issues `using FFTW` (with the
+`LatticeCore` FFT extension already wired up by the same `using FFTW`
+upstream).
+
+Two orthogonal mechanisms are used here:
+
+- **Single-sublattice topologies** (`Square`, `Triangular`): they
+  share the row-major site-index ↔ Bravais-cell layout used by
+  `LineLattice` / `SimpleSquareLattice` upstream, so we register the
+  upstream opt-in hooks `LatticeCore._has_known_grid` /
+  `LatticeCore._reshape_state` and let `LatticeCoreFFTWExt` drive the
+  FFT directly.
+
+- **Multi-sublattice topologies** (`Honeycomb`, `Kagome`, `Lieb`,
+  `UnionJack`, `Dice`, `ShastrySutherland`): the natural state layout
+  is a 3-axis grid `(nsub, Lx, Ly)`, which doesn't match the upstream
+  hook contract (a 2D reshape sized to `ml.mesh`). Instead we
+  override `LatticeCore._structure_factor_fast(::HasReciprocal,
+  ::Lattice{Topo,T}, ...)` ourselves: one column-major `reshape`
+  splits the state by sublattice, each per-sublattice plane is
+  FFT'd with the same prephase trick used upstream, and the
+  per-sublattice contributions are combined coherently in k-space
+  with the basis-position phase factor `exp(-i k · d_α)` before
+  taking `|·|² / N`.
+
+The FFT path requires:
+
+- both axes periodic (already enforced by `reciprocal_support(lat)`
+  returning `HasReciprocal()` only when neither axis is open),
+- `RowMajor` indexing (the default), since the closed-form
+  `state[i]` ↔ `(cx, cy, α)` decomposition is what the FFT consumes,
+- and `ml::PeriodicMomentumLattice` with `ml.mesh == (Lx, Ly)`.
+
+If any precondition fails we fall back to the naive O(N · M) loop
+through `LatticeCore._structure_factor_naive`, so loading the
+extension never changes results — only performance.
+"""
+Lattice2DFFTWExt
+
+# ---- Single-sublattice opt-in ---------------------------------------
+#
+# `Square` and `Triangular` have one site per unit cell, so the
+# state-vector layout matches the LatticeCore reference contract
+# (`reshape(state, (Lx, Ly))`). Register the upstream opt-in hooks
+# directly — the FFT path for these topologies then reuses
+# `LatticeCoreFFTWExt._structure_factor_fft` unchanged.
+
+LatticeCore._has_known_grid(lat::Lattice2D.Lattice{Lattice2D.Square}) =
+    _is_rowmajor_periodic(lat)
+LatticeCore._has_known_grid(lat::Lattice2D.Lattice{Lattice2D.Triangular}) =
+    _is_rowmajor_periodic(lat)
+
+LatticeCore._reshape_state(::Lattice2D.Lattice{Lattice2D.Square}, state, dims) =
+    reshape(state, dims)
+LatticeCore._reshape_state(::Lattice2D.Lattice{Lattice2D.Triangular}, state, dims) =
+    reshape(state, dims)
+
+# ---- Multi-sublattice override --------------------------------------
+#
+# For these topologies the upstream 2D-reshape hook isn't expressive
+# enough; we override the trait-dispatched fast path directly. The
+# method below is strictly more specific than
+# `LatticeCoreFFTWExt`'s own `(::HasReciprocal, ::AbstractLattice, ...)`
+# method so dispatch picks ours for `Lattice{Topo,T}` whenever this
+# extension is loaded.
+const _MultiSublatticeTopo = Union{
+    Lattice2D.Honeycomb,
+    Lattice2D.Kagome,
+    Lattice2D.Lieb,
+    Lattice2D.UnionJack,
+    Lattice2D.Dice,
+    Lattice2D.ShastrySutherland,
+}
+
+function LatticeCore._structure_factor_fast(
+    ::LatticeCore.HasReciprocal,
+    lat::Lattice2D.Lattice{Topo,T},
+    state::AbstractVector,
+    ml::LatticeCore.AbstractMomentumLattice,
+) where {Topo<:_MultiSublatticeTopo,T}
+    if _multi_sub_eligible(lat, ml)
+        return _structure_factor_fft_multisub(lat, state, ml)
+    else
+        return LatticeCore._structure_factor_naive(lat, state, ml)
+    end
+end
+
+# ---- Eligibility helpers --------------------------------------------
+
+# RowMajor + fully periodic. Cylinder / OBC already gets filtered out
+# by `reciprocal_support(lat) == NoReciprocal()` upstream, but we
+# guard explicitly so the fast path is robust to future trait
+# refinements.
+function _is_rowmajor_periodic(lat::Lattice2D.Lattice)
+    lat.indexing isa LatticeCore.RowMajor || return false
+    return all(ax isa LatticeCore.PeriodicAxis for ax in lat.boundary.axes)
+end
+
+function _multi_sub_eligible(
+    lat::Lattice2D.Lattice, ml::LatticeCore.AbstractMomentumLattice
+)
+    ml isa LatticeCore.PeriodicMomentumLattice || return false
+    _is_rowmajor_periodic(lat) || return false
+    st = LatticeCore.size_trait(lat)
+    st isa LatticeCore.FiniteSize || return false
+    return st.dims == ml.mesh
+end
+
+# ---- FFT core for multi-sublattice Bravais lattices -----------------
+#
+# For a `Lattice{Topo,T}` with `nsub` sublattices and RowMajor
+# indexing,
+#
+#     site_index(cx, cy, α) = ((cy - 1) * Lx + (cx - 1)) * nsub + α,
+#
+# so `reshape(state, (nsub, Lx, Ly))` gives a 3-axis array
+# `M[α, cx, cy]` whose `α`-th slice is the per-sublattice "image"
+# of the state. The position of every site decomposes as
+#
+#     r_i = (cx - 1) a₁ + (cy - 1) a₂ + d_α,
+#
+# with `a₁`, `a₂` the Bravais primitive vectors and `d_α` the
+# sublattice offset inside the unit cell. Substituting into the
+# defining sum,
+#
+#     Σ_i s_i e^{-i k · r_i}
+#       = Σ_α e^{-i k · d_α}
+#           · Σ_{cx, cy} M[α, cx, cy] e^{-i k · ((cx-1) a₁ + (cy-1) a₂)}.
+#
+# The cell-index sum is exactly a 2D DFT of the `α`-th slice once we
+# express `k` on the reciprocal mesh `k = B · frac` with
+# `B^T A = 2π I`: then `k · a_d = 2π frac_d`, and the prephase
+# trick used upstream (multiply by `cis(-2π Σ_d frac0_d (n_d - 1))`)
+# absorbs the mesh offset into the input array.
+function _structure_factor_fft_multisub(
+    lat::Lattice2D.Lattice{Topo,T},
+    state::AbstractVector,
+    ml::LatticeCore.PeriodicMomentumLattice{2,Tk},
+) where {Topo,T,Tk}
+    Lx, Ly = lat.Lx, lat.Ly
+    dims = (Lx, Ly)
+    nsub = LatticeCore.num_sublattices(lat)
+    Nsites = Lx * Ly * nsub
+    Nk = Lx * Ly
+
+    # `state` is laid out site-by-site with sublattice innermost. The
+    # column-major reshape onto `(nsub, Lx, Ly)` therefore satisfies
+    # `grid[α, cx, cy] = state[((cy - 1) * Lx + (cx - 1)) * nsub + α]`.
+    grid = reshape(state, (nsub, Lx, Ly))
+
+    B = LatticeCore.reciprocal_basis(ml)
+    # Fractional offset of the mesh (per axis, scaled by 1/N_d).
+    # `idx = 1` corresponds to `n = 0` per axis, so `B \ k_point(ml, 1)`
+    # is exactly `offset / N` along each axis.
+    frac0 = SVector{2,Float64}(B \ LatticeCore.k_point(ml, 1))
+
+    # Sublattice offsets in real space, as `SVector{2}` for cheap
+    # `dot(k, d_α)` later.
+    uc = Lattice2D.get_unit_cell(Topo)
+    sub_offsets = SVector{2,Float64}[
+        SVector{2,Float64}(p[1], p[2]) for p in uc.sublattice_positions
+    ]
+
+    # Accumulator in k-space, shaped to match the (Lx, Ly) k-grid.
+    acc = zeros(ComplexF64, dims)
+
+    # Workspace for the per-sublattice prephased grid; reused across
+    # sublattices to avoid an O(nsub) allocation churn.
+    plane = Array{ComplexF64,2}(undef, dims)
+
+    @inbounds for α in 1:nsub
+        # Copy slice `grid[α, :, :]` into `plane`, applying the mesh
+        # prephase. When the offset is exactly zero (Γ-centred mesh)
+        # we skip the multiplication entirely.
+        if iszero(frac0[1]) && iszero(frac0[2])
+            for cy in 1:Ly, cx in 1:Lx
+                plane[cx, cy] = ComplexF64(grid[α, cx, cy])
+            end
+        else
+            for cy in 1:Ly, cx in 1:Lx
+                ph = frac0[1] * (cx - 1) + frac0[2] * (cy - 1)
+                plane[cx, cy] = ComplexF64(grid[α, cx, cy]) * cis(-2π * ph)
+            end
+        end
+
+        F = fft(plane)
+
+        # Multiply by the sublattice basis-position phase
+        # `e^{-i k · d_α}` and accumulate into `acc`. `k` at index
+        # `(idx_x, idx_y)` is `B * frac`, with
+        # `frac_d = (idx_d - 1 + offset_d) / N_d`.
+        d_α = sub_offsets[α]
+        for idx_y in 1:Ly, idx_x in 1:Lx
+            frac = SVector{2,Float64}(
+                (idx_x - 1) / Lx + frac0[1], (idx_y - 1) / Ly + frac0[2]
+            )
+            k = B * frac
+            phase = cis(-dot(k, d_α))
+            acc[idx_x, idx_y] += F[idx_x, idx_y] * phase
+        end
+    end
+
+    # Normalisation matches the naive `S(k) = |Σ s_i e^{-i k·r_i}|² / N`
+    # convention, where `N` is the total number of sites (not k-points).
+    out = Vector{Float64}(undef, Nk)
+    @inbounds for i in eachindex(acc)
+        out[i] = abs2(acc[i]) / Nsites
+    end
+    return out
+end
+
+end # module Lattice2DFFTWExt

--- a/test/core/test_structure_factor_fft.jl
+++ b/test/core/test_structure_factor_fft.jl
@@ -1,0 +1,197 @@
+using FFTW
+using LatticeCore
+using LinearAlgebra
+using Random
+using StaticArrays
+
+# Build state values that realise a plane wave at a chosen k-target.
+# For a Bravais multi-sublattice lattice with positions r_i,
+# `s_i = exp(i k_target · r_i)` makes
+#     Σ_i s_i e^{-i k r_i} = Σ_i e^{i (k_target - k) · r_i}
+# vanish off `k_target` (mod reciprocal-lattice vectors) and equal
+# `Nsites` at `k_target`, so `S(k_target) = Nsites`.
+_plane_wave_state(lat, k_target) =
+    [cis(dot(k_target, position(lat, i))) for i in 1:num_sites(lat)]
+
+@testset "structure_factor FFT path (Lattice2DFFTWExt)" begin
+    Random.seed!(20260429)
+
+    @testset "FFT vs naive on every Bravais topology" begin
+        # Random states, MP mesh from `reciprocal_lattice`.
+        for Topo in (Square, Triangular, Honeycomb, Kagome, Lieb,
+                     UnionJack, Dice, ShastrySutherland)
+            for (Lx, Ly) in ((4, 4), (6, 4))
+                lat = build_lattice(Topo, Lx, Ly)
+                ml = reciprocal_lattice(lat)
+                for trial in 1:2
+                    state = randn(num_sites(lat))
+                    fast = structure_factor(lat, state, ml)
+                    slow = LatticeCore._structure_factor_naive(lat, state, ml)
+                    @test fast ≈ slow rtol = 1e-9
+                end
+            end
+        end
+    end
+
+    @testset "FFT vs naive on Γ-centred mesh" begin
+        # `gamma_centered` exercises the no-prephase branch in the FFT
+        # path (frac0 == 0). Cover one single-sublattice topology and
+        # one multi-sublattice topology.
+        for Topo in (Triangular, Kagome)
+            lat = build_lattice(Topo, 6, 6)
+            A = basis_vectors(lat)
+            B = SMatrix{2,2,Float64}(2π * inv(transpose(A)))
+            ml = LatticeCore.gamma_centered(B, (lat.Lx, lat.Ly))
+            state = randn(num_sites(lat))
+            fast = structure_factor(lat, state, ml)
+            slow = LatticeCore._structure_factor_naive(lat, state, ml)
+            @test fast ≈ slow rtol = 1e-9
+        end
+    end
+
+    # ---- Analytical k-space checks ---------------------------------
+    #
+    # The defining identity `S(k) = (1/N) |Σ_i s_i e^{-i k r_i}|²`
+    # gives closed-form values for a few canonical states. We
+    # cross-check those against both the naive reference loop and the
+    # FFT-accelerated path:
+    #
+    # - Uniform state (`s_i ≡ 1`): peaks at k = 0 with `S(Γ) = Nsites`,
+    #   and `S(k) = 0` at every other Bragg-mesh k inside the BZ
+    #   (their cell sum vanishes).
+    #
+    # - Plane wave at `k_target` (`s_i = exp(i k_target · r_i)`): peaks
+    #   at `k = k_target` with `S(k_target) = Nsites`. Useful for
+    #   multi-sublattice topologies where the basis-position phase
+    #   factor `exp(-i k · d_α)` shows up explicitly.
+
+    @testset "Triangular: uniform state peaks at Γ" begin
+        lat = build_lattice(Triangular, 6, 6)
+        A = basis_vectors(lat)
+        B = SMatrix{2,2,Float64}(2π * inv(transpose(A)))
+        ml = LatticeCore.gamma_centered(B, (lat.Lx, lat.Ly))
+        N = num_sites(lat)
+        state = ones(Float64, N)
+        S = structure_factor(lat, state, ml)
+        @test S[1] ≈ Float64(N)
+        @test maximum(@view S[2:end]) < 1e-9
+    end
+
+    @testset "Triangular: stripe (-1)^(cx+cy) peaks at the M-point" begin
+        # A stripe of cell-index parity is a plane wave at
+        # `k_M = (b₁ + b₂) / 2`, which on the Γ-centred 6×6 mesh
+        # lands exactly on a mesh point; S at that k equals Nsites.
+        lat = build_lattice(Triangular, 6, 6)
+        A = basis_vectors(lat)
+        B = SMatrix{2,2,Float64}(2π * inv(transpose(A)))
+        ml = LatticeCore.gamma_centered(B, (lat.Lx, lat.Ly))
+        N = num_sites(lat)
+        state = Vector{Float64}(undef, N)
+        for i in 1:N
+            coord = LatticeCore.lattice_coord(lat.indexing, (lat.Lx, lat.Ly), 1, i)
+            cx, cy = coord.cell
+            state[i] = (-1.0)^(cx + cy)
+        end
+        S = structure_factor(lat, state, ml)
+        @test maximum(S) ≈ Float64(N) rtol = 1e-10
+        # And the peak must sit at k = b₁/2 + b₂/2 (M-point).
+        peak_k = ml.k_points[argmax(S)]
+        b1 = SVector{2}(B[:, 1])
+        b2 = SVector{2}(B[:, 2])
+        @test peak_k ≈ (b1 + b2) / 2 rtol = 1e-10
+    end
+
+    @testset "Honeycomb: uniform state peaks at Γ with value Nsites" begin
+        lat = build_lattice(Honeycomb, 4, 4)
+        A = basis_vectors(lat)
+        B = SMatrix{2,2,Float64}(2π * inv(transpose(A)))
+        ml = LatticeCore.gamma_centered(B, (lat.Lx, lat.Ly))
+        N = num_sites(lat)
+        state = ones(Float64, N)
+        S = structure_factor(lat, state, ml)
+        @test S[1] ≈ Float64(N)
+        @test maximum(@view S[2:end]) < 1e-9
+    end
+
+    @testset "Honeycomb: plane wave at a chosen mesh k" begin
+        # Build s_i = exp(i k_target · r_i) and verify the peak lands
+        # exactly at k_target. This exercises the basis-position phase
+        # factor `exp(-i k · d_α)` in the multi-sublattice FFT path.
+        lat = build_lattice(Honeycomb, 4, 4)
+        ml = reciprocal_lattice(lat)
+        N = num_sites(lat)
+        for target_idx in (1, 4, 7, 13)
+            k_target = ml.k_points[target_idx]
+            state = _plane_wave_state(lat, k_target)
+            S = structure_factor(lat, state, ml)
+            @test argmax(S) == target_idx
+            @test S[target_idx] ≈ Float64(N) rtol = 1e-10
+            # All other k-points must vanish to FP noise.
+            S_off = copy(S); S_off[target_idx] = 0.0
+            @test maximum(S_off) < 1e-9
+        end
+    end
+
+    @testset "Kagome: uniform state peaks at Γ with value Nsites" begin
+        lat = build_lattice(Kagome, 4, 4)
+        A = basis_vectors(lat)
+        B = SMatrix{2,2,Float64}(2π * inv(transpose(A)))
+        ml = LatticeCore.gamma_centered(B, (lat.Lx, lat.Ly))
+        N = num_sites(lat)
+        state = ones(Float64, N)
+        S = structure_factor(lat, state, ml)
+        @test S[1] ≈ Float64(N)
+        @test maximum(@view S[2:end]) < 1e-9
+    end
+
+    @testset "Kagome: plane wave at a chosen mesh k" begin
+        lat = build_lattice(Kagome, 4, 4)
+        ml = reciprocal_lattice(lat)
+        N = num_sites(lat)
+        for target_idx in (1, 5, 11)
+            k_target = ml.k_points[target_idx]
+            state = _plane_wave_state(lat, k_target)
+            S = structure_factor(lat, state, ml)
+            @test argmax(S) == target_idx
+            @test S[target_idx] ≈ Float64(N) rtol = 1e-10
+        end
+    end
+
+    # ---- Fallback paths -------------------------------------------
+
+    @testset "FFT path falls back on non-RowMajor indexing" begin
+        # ColMajor / Snake state layouts don't match the closed-form
+        # `(cy-1)*Lx + (cx-1)*nsub + α` site index, so the multi-sub
+        # eligibility check should reject them and route through the
+        # naive helper. Numerical equality is the contract.
+        for indexing in (ColMajor(), Snake())
+            lat = build_lattice(Honeycomb, 4, 4; indexing=indexing)
+            ml = reciprocal_lattice(lat)
+            state = randn(num_sites(lat))
+            fast = structure_factor(lat, state, ml)
+            slow = LatticeCore._structure_factor_naive(lat, state, ml)
+            @test fast ≈ slow rtol = 1e-12
+        end
+
+        # Single-sublattice opt-in (`Triangular`) likewise refuses
+        # non-RowMajor.
+        for indexing in (ColMajor(), Snake())
+            lat = build_lattice(Triangular, 4, 4; indexing=indexing)
+            @test LatticeCore._has_known_grid(lat) == false
+        end
+    end
+
+    @testset "Single-sublattice opt-in matches LC FFTW path" begin
+        # For the single-sublattice topologies (`Square`,
+        # `Triangular`) we register `LatticeCore._has_known_grid` /
+        # `LatticeCore._reshape_state` and let `LatticeCoreFFTWExt`
+        # drive the FFT. Lock that opt-in down.
+        for Topo in (Square, Triangular)
+            lat = build_lattice(Topo, 4, 4)
+            @test LatticeCore._has_known_grid(lat) == true
+            v = collect(1:num_sites(lat))
+            grid = LatticeCore._reshape_state(lat, v, (lat.Lx, lat.Ly))
+            @test size(grid) == (lat.Lx, lat.Ly)
+        end
+    end
+end

--- a/test/core/test_structure_factor_fft.jl
+++ b/test/core/test_structure_factor_fft.jl
@@ -10,16 +10,18 @@ using StaticArrays
 #     Σ_i s_i e^{-i k r_i} = Σ_i e^{i (k_target - k) · r_i}
 # vanish off `k_target` (mod reciprocal-lattice vectors) and equal
 # `Nsites` at `k_target`, so `S(k_target) = Nsites`.
-_plane_wave_state(lat, k_target) =
+function _plane_wave_state(lat, k_target)
     [cis(dot(k_target, position(lat, i))) for i in 1:num_sites(lat)]
+end
 
 @testset "structure_factor FFT path (Lattice2DFFTWExt)" begin
     Random.seed!(20260429)
 
     @testset "FFT vs naive on every Bravais topology" begin
         # Random states, MP mesh from `reciprocal_lattice`.
-        for Topo in (Square, Triangular, Honeycomb, Kagome, Lieb,
-                     UnionJack, Dice, ShastrySutherland)
+        for Topo in (
+            Square, Triangular, Honeycomb, Kagome, Lieb, UnionJack, Dice, ShastrySutherland
+        )
             for (Lx, Ly) in ((4, 4), (6, 4))
                 lat = build_lattice(Topo, Lx, Ly)
                 ml = reciprocal_lattice(lat)
@@ -127,7 +129,8 @@ _plane_wave_state(lat, k_target) =
             @test argmax(S) == target_idx
             @test S[target_idx] ≈ Float64(N) rtol = 1e-10
             # All other k-points must vanish to FP noise.
-            S_off = copy(S); S_off[target_idx] = 0.0
+            S_off = copy(S);
+            S_off[target_idx] = 0.0
             @test maximum(S_off) < 1e-9
         end
     end


### PR DESCRIPTION
## Summary

- Add `Lattice2DFFTWExt` (weakdep `FFTW`) that opts every periodic `Lattice{Topo,T}` topology into the FFT-based `structure_factor` fast path landed upstream in `LatticeCore` 0.10.2.
- Single-sublattice (`Square`, `Triangular`) reuses the upstream `LatticeCoreFFTWExt` path by registering `LatticeCore._has_known_grid` / `LatticeCore._reshape_state` hooks; multi-sublattice (`Honeycomb`, `Kagome`, `Lieb`, `UnionJack`, `Dice`, `ShastrySutherland`) overrides `LatticeCore._structure_factor_fast(::HasReciprocal, ::Lattice{Topo,T}, ...)` with a sublattice-aware FFT (column-major reshape into `(nsub, Lx, Ly)`, one 2D FFT per sublattice, basis-position phase `exp(-i k · d_α)` combined in k-space).
- Eligibility is `RowMajor` indexing + fully periodic + `ml::PeriodicMomentumLattice` matching the lattice grid; everything else falls back to the naive O(N·M) loop.

Depends on LatticeCore PRs #45 + #46 (hook expose).

## Test plan

- [x] FFT-vs-naive agreement on random states across all eight topologies (`Square`, `Triangular`, `Honeycomb`, `Kagome`, `Lieb`, `UnionJack`, `Dice`, `ShastrySutherland`) on MP meshes
- [x] FFT-vs-naive agreement on Γ-centred meshes (no-prephase branch)
- [x] Analytical k-space peak identities: uniform state → Γ peak with value `Nsites` (Triangular, Honeycomb, Kagome)
- [x] Analytical Triangular `(-1)^(cx+cy)` stripe → M-point peak with value `Nsites`
- [x] Honeycomb / Kagome plane-wave states peak at the chosen mesh k-point with value `Nsites`
- [x] Non-RowMajor indexing (`ColMajor`, `Snake`) routed through the naive helper
- [x] Single-sublattice opt-in registration verified for `Square` / `Triangular`
- [x] Aqua suite remains green
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes locally with `LatticeCore` developed against the hook-expose branch