### PR TITLE
fix(docs): use docs project for generate_features.jl deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["souta shimozono"]
 
 [deps]

--- a/docs/src/generate_features.jl
+++ b/docs/src/generate_features.jl
@@ -1,6 +1,3 @@
-using Pkg: Pkg
-Pkg.activate(joinpath(@__DIR__, "..", ".."))
-push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "src"))
 using Lattice2D
 using Plots
 using LinearAlgebra


### PR DESCRIPTION
## Summary

`docs/src/generate_features.jl` が package root を `Pkg.activate` してから `using Plots` していたため、docs CI で root deps が instantiate されず Plots が見つからず失敗していた。

docs project は既に `Lattice2D` + `Plots` を deps に持っているので、root activate を撤去して docs project の deps をそのまま使う。

bump 0.3.5 → 0.3.6.

## Test plan

- [ ] CI `Documentation` workflow が green になる