### PR TITLE
feat(plots-ext): plot_state recipe for site-resolved scalar fields

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["souta shimozono"]
 
 [deps]

--- a/ext/Lattice2DPlotsExt.jl
+++ b/ext/Lattice2DPlotsExt.jl
@@ -213,4 +213,119 @@ function Lattice2D.plot_bonds(
     return p
 end
 
+# ---- plot_state -----------------------------------------------------
+
+function _site_xy(lat::Lattice2D.Lattice)
+    N = num_sites(lat)
+    xs = Vector{Float64}(undef, N)
+    ys = Vector{Float64}(undef, N)
+    for i in 1:N
+        p = position(lat, i)
+        xs[i] = Float64(p[1])
+        ys[i] = Float64(p[2])
+    end
+    return xs, ys
+end
+
+function _bond_segments(lat::Lattice2D.Lattice)
+    seg_x = Float64[]
+    seg_y = Float64[]
+    for b in bonds(lat)
+        src = position(lat, b.i)
+        dst_local = src + b.vector
+        push!(seg_x, Float64(src[1]), Float64(dst_local[1]), NaN)
+        push!(seg_y, Float64(src[2]), Float64(dst_local[2]), NaN)
+    end
+    return seg_x, seg_y
+end
+
+_is_discrete_state(::AbstractVector{Bool}) = true
+function _is_discrete_state(state::AbstractVector{<:Integer})
+    return length(unique(state)) <= 12
+end
+_is_discrete_state(::AbstractVector) = false
+
+const _DISCRETE_PALETTE = (
+    :steelblue,
+    :tomato,
+    :seagreen,
+    :goldenrod,
+    :mediumpurple,
+    :sandybrown,
+    :hotpink,
+    :gray,
+    :olive,
+    :teal,
+    :crimson,
+    :darkorange,
+)
+
+function Lattice2D.plot_state(
+    lat::Lattice2D.Lattice,
+    state::AbstractVector;
+    colormap=:viridis,
+    marker_size::Real=12,
+    show_bonds::Bool=true,
+    bond_color=:lightgray,
+    bond_width::Real=1.0,
+    title=nothing,
+    aspect_ratio=:equal,
+    kwargs...,
+)
+    N = num_sites(lat)
+    length(state) == N || throw(
+        DimensionMismatch(
+            "plot_state expects length(state) == num_sites(lat); got $(length(state)) vs $N",
+        ),
+    )
+
+    xs, ys = _site_xy(lat)
+
+    p = Plots.plot(;
+        aspect_ratio=aspect_ratio,
+        xlabel="x",
+        ylabel="y",
+        title=title,
+        legend=:topright,
+        kwargs...,
+    )
+
+    if show_bonds
+        seg_x, seg_y = _bond_segments(lat)
+        Plots.plot!(p, seg_x, seg_y; color=bond_color, lw=bond_width, label="")
+    end
+
+    if _is_discrete_state(state)
+        labels = sort(unique(state))
+        for (k, lbl) in enumerate(labels)
+            mask = state .== lbl
+            colour = _DISCRETE_PALETTE[mod1(k, length(_DISCRETE_PALETTE))]
+            Plots.scatter!(
+                p,
+                xs[mask],
+                ys[mask];
+                ms=marker_size,
+                mc=colour,
+                markerstrokewidth=0,
+                label=string(lbl),
+            )
+        end
+    else
+        zs = Float64.(state)
+        Plots.scatter!(
+            p,
+            xs,
+            ys;
+            ms=marker_size,
+            marker_z=zs,
+            color=colormap,
+            markerstrokewidth=0,
+            label="",
+            colorbar=true,
+        )
+    end
+
+    return p
+end
+
 end # module Lattice2DPlotsExt

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -116,6 +116,11 @@ include("core/element_api.jl")
 include("core/constructor.jl")
 include("utils/iterator.jl")
 
+# ---- Plots-extension stubs ------------------------------------------
+#
+# Concrete methods live in `ext/Lattice2DPlotsExt.jl` and are loaded
+# automatically once `Plots` is in scope.
+
 """
     plot_bonds(lat::Lattice; bond_types=:all, color_by=:type, kwargs...)
 
@@ -133,6 +138,24 @@ list and worked examples.
 """
 function plot_bonds end
 
+"""
+    plot_state(lat::Lattice, state::AbstractVector;
+               colormap=:viridis, marker_size=12, kwargs...) → Plots.Plot
+
+Visualise a per-site `state::AbstractVector` (with `length(state) ==
+num_sites(lat)`) as a coloured scatter on top of the lattice
+geometry. Both continuous fields (energy density, charge density,
+expectation values) and discrete labels (`Bool`, small-cardinality
+`Int` spin / clock-model configurations) are supported through the
+same call.
+
+The concrete method lives in the `Lattice2DPlotsExt` package
+extension and is loaded automatically once `Plots` is in scope. See
+the `Lattice2DPlotsExt` module docstring for the full keyword list
+and worked examples.
+"""
+function plot_state end
+
 # ---- Exports --------------------------------------------------------
 
 # Lattice2D-local types and functions
@@ -142,6 +165,7 @@ export build_lattice
 export sublattice_layout
 export num_bonds, num_plaquettes, bond_type
 export plot_bonds
+export plot_state
 export AVAILABLE_LATTICES
 export Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
 

--- a/test/core/test_plots_ext_state.jl
+++ b/test/core/test_plots_ext_state.jl
@@ -1,0 +1,82 @@
+using Plots
+using LatticeCore
+
+# `runtests.jl` already sets `ENV["GKSwstype"] = "100"` so GR runs in
+# a headless mode. We only build the figure objects and inspect their
+# series — nothing is written to disk — but the env var still applies
+# in case any kwarg path triggers a backend init.
+
+@testset "Lattice2DPlotsExt — plot_state" begin
+    @testset "Extension is loaded once Plots is in scope" begin
+        ext = Base.get_extension(Lattice2D, :Lattice2DPlotsExt)
+        @test ext !== nothing
+    end
+
+    @testset "Continuous state on Square (PBC) returns a Plots.Plot" begin
+        lat = build_lattice(Square, 4, 4)
+        N = num_sites(lat)
+        state = [Float64(i) for i in 1:N]
+
+        p = plot_state(lat, state)
+        @test p isa Plots.Plot
+
+        # Bonds (lines) + scatter series should both be present.
+        nseries = length(p.series_list)
+        @test nseries >= 2
+
+        # The continuous code path sets `marker_z` on the scatter series.
+        scatter_series = filter(s -> s[:seriestype] === :scatter, p.series_list)
+        @test !isempty(scatter_series)
+        @test any(!isnothing(s[:marker_z]) for s in scatter_series)
+    end
+
+    @testset "Bool state on Honeycomb uses discrete palette" begin
+        lat = build_lattice(Honeycomb, 3, 3)
+        N = num_sites(lat)
+        state = [iseven(i) for i in 1:N]
+
+        p = plot_state(lat, state; marker_size=8, title="bool")
+        @test p isa Plots.Plot
+
+        # Discrete path: one scatter series per unique label, none of
+        # which carries a marker_z (those would force a colorbar).
+        scatter_series = filter(s -> s[:seriestype] === :scatter, p.series_list)
+        @test length(scatter_series) == length(unique(state))
+        @test all(isnothing(s[:marker_z]) for s in scatter_series)
+    end
+
+    @testset "Integer (small distinct count) state is discrete" begin
+        lat = build_lattice(Triangular, 3, 3)
+        N = num_sites(lat)
+        # 3-state clock model: labels 1, 2, 3.
+        state = [mod1(i, 3) for i in 1:N]
+
+        p = plot_state(lat, state)
+        @test p isa Plots.Plot
+
+        scatter_series = filter(s -> s[:seriestype] === :scatter, p.series_list)
+        @test length(scatter_series) == 3
+    end
+
+    @testset "show_bonds=false drops the bond series" begin
+        lat = build_lattice(Square, 3, 3)
+        state = randn(num_sites(lat))
+
+        p_with = plot_state(lat, state)
+        p_without = plot_state(lat, state; show_bonds=false)
+
+        @test length(p_without.series_list) < length(p_with.series_list)
+    end
+
+    @testset "Length mismatch throws DimensionMismatch" begin
+        lat = build_lattice(Square, 3, 3)
+        @test_throws DimensionMismatch plot_state(lat, randn(num_sites(lat) + 1))
+    end
+
+    @testset "Works on multi-sublattice topology (Kagome)" begin
+        lat = build_lattice(Kagome, 3, 3)
+        state = randn(num_sites(lat))
+        p = plot_state(lat, state; colormap=:plasma)
+        @test p isa Plots.Plot
+    end
+end


### PR DESCRIPTION
## Summary
- Add `plot_state(lat, state; colormap, marker_size, ...)` in a new `Lattice2DPlotsExt` package extension that scatters per-site values on top of the lattice bonds.
- Heuristic dispatch: `Bool` and small-cardinality `Int` arrays render as discrete-coloured legends from a 12-colour qualitative palette; `Float`/general numeric arrays render as a continuous `marker_z` field with the supplied colormap (default `:viridis`) and a colorbar.
- Plots is registered as a dual `[deps]` + `[weakdeps]` entry so the new extension loads automatically once `Plots` is in scope, while preserving the existing transitive `using Plots` path that downstream code relies on (no breaking change to the existing `LatticeCorePlotsExt` recipes).

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (4325/4325 + Aqua 11/11) on Julia 1.12
- [x] Continuous `Float64` state on `Square` produces a `Plots.Plot` with bond + scatter series and a non-nothing `marker_z` on the scatter
- [x] `Bool` state on `Honeycomb` renders one scatter series per unique label, all with `marker_z === nothing`
- [x] 3-state `Int` clock-model state on `Triangular` renders three scatter series
- [x] `show_bonds=false` drops the bond series
- [x] Length mismatch throws `DimensionMismatch`
- [x] Multi-sublattice topology (`Kagome`) works with custom `colormap`