### PR TITLE
feat(plots-ext): Brillouin-zone helpers and BZ plot recipe

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["souta shimozono"]
 
 [deps]

--- a/ext/Lattice2DPlotsExt.jl
+++ b/ext/Lattice2DPlotsExt.jl
@@ -328,4 +328,197 @@ function Lattice2D.plot_state(
     return p
 end
 
+# ---- Brillouin zone -------------------------------------------------
+
+"""
+    Lattice2D.brillouin_zone(lat::Lattice2D.Lattice; shell::Int=2)
+        -> Vector{SVector{2,Float64}}
+
+Compute the Brillouin zone of `lat` as the Wigner-Seitz cell of its
+reciprocal lattice via half-plane intersection over the
+`(m, n) ∈ [-shell, shell]² ∖ {(0,0)}` shell of reciprocal vectors.
+Returns vertices ordered counter-clockwise around the origin.
+"""
+function Lattice2D.brillouin_zone(lat::Lattice2D.Lattice; shell::Int=2)
+    LatticeCore.reciprocal_support(lat) isa LatticeCore.HasReciprocal || throw(
+        ArgumentError(
+            "brillouin_zone requires a fully periodic Lattice (got $(lat.boundary))"
+        ),
+    )
+    ml = LatticeCore.reciprocal_lattice(lat)
+    B = LatticeCore.reciprocal_basis(ml)
+    return _brillouin_zone_from_basis(SMatrix{2,2,Float64}(B), shell)
+end
+
+"""
+    Lattice2D.high_symmetry_points(lat::Lattice2D.Lattice)
+        -> Dict{Symbol,SVector{2,Float64}}
+
+Topology-keyed dictionary of high-symmetry points (Cartesian k).
+Populated for `Square`, `Triangular`, `Honeycomb`; falls back to
+`Dict(:Gamma => 0)` for other topologies.
+"""
+function Lattice2D.high_symmetry_points(lat::Lattice2D.Lattice)
+    LatticeCore.reciprocal_support(lat) isa LatticeCore.HasReciprocal || throw(
+        ArgumentError(
+            "high_symmetry_points requires a fully periodic Lattice (got $(lat.boundary))",
+        ),
+    )
+    ml = LatticeCore.reciprocal_lattice(lat)
+    B = SMatrix{2,2,Float64}(LatticeCore.reciprocal_basis(ml))
+    return _high_symmetry_points(LatticeCore.topology(lat), B)
+end
+
+const _BZ_TOL = 1e-10
+
+function _brillouin_zone_from_basis(B::SMatrix{2,2,Float64}, shell::Int)
+    Gs = SVector{2,Float64}[]
+    for n in (-shell):shell, m in (-shell):shell
+        (m == 0 && n == 0) && continue
+        push!(Gs, B * SVector{2,Float64}(m, n))
+    end
+
+    verts = SVector{2,Float64}[]
+    nG = length(Gs)
+    for i in 1:nG
+        Gi = Gs[i]
+        rhs_i = dot(Gi, Gi) / 2
+        for j in (i + 1):nG
+            Gj = Gs[j]
+            rhs_j = dot(Gj, Gj) / 2
+            M = SMatrix{2,2,Float64}(Gi[1], Gj[1], Gi[2], Gj[2])
+            d = det(M)
+            abs(d) < _BZ_TOL && continue
+            k = M \ SVector{2,Float64}(rhs_i, rhs_j)
+            inside = true
+            for G in Gs
+                lhs = 2 * dot(k, G)
+                rhs = dot(G, G)
+                if lhs > rhs + _BZ_TOL * (1 + abs(rhs))
+                    inside = false
+                    break
+                end
+            end
+            inside || continue
+            already = false
+            for v in verts
+                if norm(v - k) < _BZ_TOL
+                    already = true
+                    break
+                end
+            end
+            already || push!(verts, k)
+        end
+    end
+
+    isempty(verts) && return verts
+
+    cx = sum(v[1] for v in verts) / length(verts)
+    cy = sum(v[2] for v in verts) / length(verts)
+    sort!(verts; by=v -> atan(v[2] - cy, v[1] - cx))
+    return verts
+end
+
+function _high_symmetry_points(
+    ::LatticeCore.TopologyTrait{:square}, B::SMatrix{2,2,Float64}
+)
+    b1 = B[:, 1]
+    b2 = B[:, 2]
+    return Dict{Symbol,SVector{2,Float64}}(
+        :Gamma => SVector{2,Float64}(0.0, 0.0),
+        :X => SVector{2,Float64}(b1 / 2),
+        :M => SVector{2,Float64}((b1 + b2) / 2),
+    )
+end
+
+function _high_symmetry_points(
+    ::LatticeCore.TopologyTrait{:triangular}, B::SMatrix{2,2,Float64}
+)
+    b1 = B[:, 1]
+    b2 = B[:, 2]
+    return Dict{Symbol,SVector{2,Float64}}(
+        :Gamma => SVector{2,Float64}(0.0, 0.0),
+        :M => SVector{2,Float64}(b1 / 2),
+        :K => SVector{2,Float64}((b1 + 2b2) / 3),
+        :K_prime => SVector{2,Float64}((2b1 + b2) / 3),
+    )
+end
+
+function _high_symmetry_points(
+    ::LatticeCore.TopologyTrait{:honeycomb}, B::SMatrix{2,2,Float64}
+)
+    return _high_symmetry_points(LatticeCore.TopologyTrait{:triangular}(), B)
+end
+
+function _high_symmetry_points(::LatticeCore.TopologyTrait, ::SMatrix{2,2,Float64})
+    return Dict{Symbol,SVector{2,Float64}}(:Gamma => SVector{2,Float64}(0.0, 0.0))
+end
+
+function Lattice2D.plot_brillouin_zone(
+    lat::Lattice2D.Lattice;
+    show_mesh::Bool=false,
+    ml::Union{Nothing,LatticeCore.AbstractMomentumLattice}=nothing,
+    show_high_symmetry::Bool=false,
+    shell::Int=2,
+    bz_color=:black,
+    bz_lw=1.5,
+    mesh_color=:steelblue,
+    mesh_size=3,
+    label_color=:crimson,
+    title=nothing,
+    kwargs...,
+)
+    verts = Lattice2D.brillouin_zone(lat; shell=shell)
+    isempty(verts) && throw(
+        ErrorException(
+            "Brillouin zone polygon is empty -- bump `shell` or check the basis"
+        ),
+    )
+
+    xs = Float64[v[1] for v in verts]
+    ys = Float64[v[2] for v in verts]
+    push!(xs, xs[1])
+    push!(ys, ys[1])
+
+    p = Plots.plot(;
+        aspect_ratio=:equal,
+        xlabel="kx",
+        ylabel="ky",
+        legend=:topright,
+        title=title === nothing ? "Brillouin zone" : title,
+        kwargs...,
+    )
+    Plots.plot!(p, xs, ys; color=bz_color, lw=bz_lw, label="BZ")
+
+    if show_mesh
+        mesh = ml === nothing ? LatticeCore.reciprocal_lattice(lat) : ml
+        M = LatticeCore.num_k_points(mesh)
+        kxs = [Float64(LatticeCore.k_point(mesh, i)[1]) for i in 1:M]
+        kys = [Float64(LatticeCore.k_point(mesh, i)[2]) for i in 1:M]
+        Plots.scatter!(
+            p, kxs, kys; mc=mesh_color, ms=mesh_size, markerstrokewidth=0, label="mesh"
+        )
+    end
+
+    if show_high_symmetry
+        hsp = Lattice2D.high_symmetry_points(lat)
+        hxs = Float64[]
+        hys = Float64[]
+        labels = String[]
+        for (name, k) in hsp
+            push!(hxs, Float64(k[1]))
+            push!(hys, Float64(k[2]))
+            push!(labels, String(name))
+        end
+        Plots.scatter!(
+            p, hxs, hys; mc=label_color, ms=5, markerstrokewidth=0, label="high-sym"
+        )
+        for (x, y, name) in zip(hxs, hys, labels)
+            Plots.annotate!(p, x, y, Plots.text(" $name", 10, label_color, :left, :bottom))
+        end
+    end
+
+    return p
+end
+
 end # module Lattice2DPlotsExt

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -156,6 +156,50 @@ and worked examples.
 """
 function plot_state end
 
+"""
+    brillouin_zone(lat::Lattice; shell::Int=2) -> Vector{SVector{2,Float64}}
+
+Compute the Brillouin zone of `lat` as the Wigner-Seitz cell of its
+reciprocal lattice. Returns an ordered list of polygon vertices in
+Cartesian k-space, walked counter-clockwise around the origin.
+
+Throws `ArgumentError` if `lat` has any open axis (no reciprocal
+lattice => no BZ).
+
+The concrete method lives in the `Lattice2DPlotsExt` package
+extension and is loaded automatically once `Plots` is in scope. See
+the `Lattice2DPlotsExt` module docstring for the algorithm and the
+`shell` keyword.
+"""
+function brillouin_zone end
+
+"""
+    high_symmetry_points(lat::Lattice) -> Dict{Symbol,SVector{2,Float64}}
+
+Topology-keyed dictionary of high-symmetry points (Gamma, X, M, K,
+...) in Cartesian k-coordinates. Currently populated for `Square`,
+`Triangular`, and `Honeycomb`; other topologies fall back to a
+singleton `:Gamma` entry.
+
+The concrete method lives in the `Lattice2DPlotsExt` package
+extension and is loaded automatically once `Plots` is in scope.
+"""
+function high_symmetry_points end
+
+"""
+    plot_brillouin_zone(lat::Lattice; show_mesh=false, ml=nothing,
+                        show_high_symmetry=false, kwargs...) -> Plots.Plot
+
+Plot the Brillouin zone of `lat` as a closed polygon. Optionally
+overlays a momentum-lattice mesh on top of the BZ and labels
+high-symmetry points.
+
+The concrete method lives in the `Lattice2DPlotsExt` package
+extension and is loaded automatically once `Plots` is in scope. See
+the `Lattice2DPlotsExt` module docstring for the full keyword list.
+"""
+function plot_brillouin_zone end
+
 # ---- Exports --------------------------------------------------------
 
 # Lattice2D-local types and functions
@@ -166,6 +210,7 @@ export sublattice_layout
 export num_bonds, num_plaquettes, bond_type
 export plot_bonds
 export plot_state
+export brillouin_zone, high_symmetry_points, plot_brillouin_zone
 export AVAILABLE_LATTICES
 export Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
 

--- a/test/core/test_brillouin_zone.jl
+++ b/test/core/test_brillouin_zone.jl
@@ -38,8 +38,9 @@ using Plots
             v_a = verts[k]
             v_b = verts[mod1(k + 1, length(verts))]
             v_c = verts[mod1(k + 2, length(verts))]
-            cross = (v_b[1] - v_a[1]) * (v_c[2] - v_b[2]) -
-                    (v_b[2] - v_a[2]) * (v_c[1] - v_b[1])
+            cross =
+                (v_b[1] - v_a[1]) * (v_c[2] - v_b[2]) -
+                (v_b[2] - v_a[2]) * (v_c[1] - v_b[1])
             @test cross > 0
         end
     end

--- a/test/core/test_brillouin_zone.jl
+++ b/test/core/test_brillouin_zone.jl
@@ -1,0 +1,121 @@
+using Plots
+
+# `runtests.jl` already sets `ENV["GKSwstype"] = "100"` so GR runs
+# headlessly. We only build the figure objects and inspect their
+# series -- nothing is written to disk -- but the env var still
+# applies in case any kwarg path triggers a backend init.
+
+@testset "Lattice2DPlotsExt -- brillouin_zone" begin
+    @testset "Extension is loaded once Plots is in scope" begin
+        ext = Base.get_extension(Lattice2D, :Lattice2DPlotsExt)
+        @test ext !== nothing
+    end
+
+    @testset "brillouin_zone throws under any open axis" begin
+        lat_obc = build_lattice(Square, 4, 4; boundary=OpenAxis())
+        @test_throws ArgumentError brillouin_zone(lat_obc)
+
+        cyl = build_lattice(
+            Square, 4, 4; boundary=LatticeBoundary((PeriodicAxis(), OpenAxis()))
+        )
+        @test_throws ArgumentError brillouin_zone(cyl)
+    end
+
+    @testset "Square BZ is a square of half-diagonal sqrt(2)*pi centred at Gamma" begin
+        lat = build_lattice(Square, 4, 4)
+        verts = brillouin_zone(lat)
+        @test length(verts) == 4
+        # All vertices at distance sqrt(2)*pi from Gamma.
+        for v in verts
+            @test norm(v) ≈ sqrt(2) * π atol = 1e-10
+        end
+        # Opposite-vertex pairs cancel through the origin.
+        c = sum(verts) / length(verts)
+        @test norm(c) <= 1e-10
+        # Vertices walk CCW: cross-products of consecutive edges are
+        # all positive.
+        for k in 1:length(verts)
+            v_a = verts[k]
+            v_b = verts[mod1(k + 1, length(verts))]
+            v_c = verts[mod1(k + 2, length(verts))]
+            cross = (v_b[1] - v_a[1]) * (v_c[2] - v_b[2]) -
+                    (v_b[2] - v_a[2]) * (v_c[1] - v_b[1])
+            @test cross > 0
+        end
+    end
+
+    @testset "Triangular BZ is a regular hexagon" begin
+        lat = build_lattice(Triangular, 4, 4)
+        verts = brillouin_zone(lat)
+        @test length(verts) == 6
+        # Equal radii (regular hexagon).
+        rs = [norm(v) for v in verts]
+        @test maximum(rs) - minimum(rs) <= 1e-10
+        # Edge lengths equal too.
+        edges = [norm(verts[mod1(k + 1, 6)] - verts[k]) for k in 1:6]
+        @test maximum(edges) - minimum(edges) <= 1e-10
+    end
+
+    @testset "Honeycomb BZ is a hexagon (same Bravais as Triangular)" begin
+        # Honeycomb shares the triangular Bravais primitives (the
+        # 2-site basis lives inside the unit cell, not in the basis
+        # itself), so its BZ has the same hexagonal shape.
+        lat_h = build_lattice(Honeycomb, 4, 4)
+        verts_h = brillouin_zone(lat_h)
+        @test length(verts_h) == 6
+        rs = [norm(v) for v in verts_h]
+        @test maximum(rs) - minimum(rs) <= 1e-10
+    end
+
+    @testset "high_symmetry_points reports the expected sets" begin
+        @test haskey(high_symmetry_points(build_lattice(Square, 4, 4)), :X)
+        @test haskey(high_symmetry_points(build_lattice(Triangular, 4, 4)), :K)
+        @test haskey(high_symmetry_points(build_lattice(Honeycomb, 4, 4)), :K)
+        # Unmapped topology falls back to the singleton Gamma.
+        hsp_kg = high_symmetry_points(build_lattice(Kagome, 4, 4))
+        @test collect(keys(hsp_kg)) == [:Gamma]
+    end
+
+    @testset "high_symmetry_points: Square X is at b1/2" begin
+        lat = build_lattice(Square, 4, 4)
+        hsp = high_symmetry_points(lat)
+        ml = reciprocal_lattice(lat)
+        B = reciprocal_basis(ml)
+        @test hsp[:X] ≈ B[:, 1] / 2 atol = 1e-10
+        @test hsp[:M] ≈ (B[:, 1] + B[:, 2]) / 2 atol = 1e-10
+        @test hsp[:Gamma] ≈ zeros(2) atol = 1e-10
+    end
+
+    @testset "plot_brillouin_zone returns a Plots.Plot for every Bravais topology" begin
+        for Topo in (Square, Triangular, Honeycomb)
+            lat = build_lattice(Topo, 4, 4)
+            p = plot_brillouin_zone(lat)
+            @test p isa Plots.Plot
+            # `BZ` polygon series is registered.
+            labels = [String(s[:label]) for s in p.series_list]
+            @test "BZ" in labels
+        end
+    end
+
+    @testset "plot_brillouin_zone with show_mesh overlays the mesh series" begin
+        lat = build_lattice(Square, 6, 6)
+        p = plot_brillouin_zone(lat; show_mesh=true)
+        labels = [String(s[:label]) for s in p.series_list]
+        @test "mesh" in labels
+    end
+
+    @testset "plot_brillouin_zone with explicit ml overrides the default" begin
+        lat = build_lattice(Square, 4, 4)
+        ml = gamma_centered(reciprocal_basis(reciprocal_lattice(lat)), (8, 8))
+        p = plot_brillouin_zone(lat; show_mesh=true, ml=ml)
+        labels = [String(s[:label]) for s in p.series_list]
+        @test "mesh" in labels
+    end
+
+    @testset "plot_brillouin_zone with show_high_symmetry adds high-sym points" begin
+        lat = build_lattice(Triangular, 4, 4)
+        p = plot_brillouin_zone(lat; show_high_symmetry=true)
+        labels = [String(s[:label]) for s in p.series_list]
+        @test "high-sym" in labels
+    end
+end


### PR DESCRIPTION
## Summary

- Add `Lattice2DPlotsExt` package extension exposing the Brillouin-zone helper trio:
  - `brillouin_zone(lat; shell=2)` returns the BZ polygon as the Wigner-Seitz cell of the reciprocal lattice. The algorithm intersects half-planes `2 k . G <= |G|^2` from a small shell of reciprocal vectors and orders the resulting vertices CCW around the origin (centroid is exactly Γ for any centrosymmetric BZ).
  - `high_symmetry_points(lat)` returns the curated standard k-point dictionary for `Square` (Γ, X, M), `Triangular` (Γ, M, K, K′), and `Honeycomb` (Γ, M, K, K′ — same Bravais as Triangular), with a singleton-Γ fallback for other topologies.
  - `plot_brillouin_zone(lat; show_mesh, ml, show_high_symmetry, ...)` draws the BZ polygon, optionally overlaying a momentum-lattice mesh and labelled high-symmetry points.
- Wire `Plots` as a `[weakdeps]` extension trigger; existing `[deps]` entry is preserved so downstream code that loads `Plots` transitively keeps working.
- Lattice2D's `Lattice` shape is unchanged: function stubs in `src/Lattice2D.jl`, all logic in `ext/Lattice2DPlotsExt.jl`, no LatticeCore changes.

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (4346 tests + Aqua).
- [x] BZ geometry: Square BZ has 4 vertices at distance √2·π from Γ with CCW ordering; Triangular and Honeycomb BZs are regular hexagons with equal vertex radii and edge lengths.
- [x] `brillouin_zone` throws `ArgumentError` under any open axis (full OBC and cylinder).
- [x] `high_symmetry_points` reports the expected sets per topology and the documented coordinates (e.g. Square X = b1/2, M = (b1+b2)/2).
- [x] `plot_brillouin_zone` returns a `Plots.Plot` for every Bravais topology and registers the `BZ` / `mesh` / `high-sym` series labels under the corresponding keyword combinations.
- [x] Extension precompiles and loads via `Base.get_extension(Lattice2D, :Lattice2DPlotsExt)` once `Plots` is in scope.