### PR TITLE
feat(api): add convenience builders for all 8 topologies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["souta shimozono"]
 
 [deps]

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -115,6 +115,7 @@ include("core/cache.jl")
 include("core/element_api.jl")
 include("core/constructor.jl")
 include("utils/iterator.jl")
+include("api/builders.jl")
 
 # ---- Plots-extension stubs ------------------------------------------
 #
@@ -213,6 +214,9 @@ export plot_state
 export brillouin_zone, high_symmetry_points, plot_brillouin_zone
 export AVAILABLE_LATTICES
 export Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
+
+# Convenience builders (thin wrappers around `build_lattice`)
+export square, triangular, honeycomb, kagome, lieb, union_jack, dice, shastry_sutherland
 
 # Re-exports from LatticeCore so `using Lattice2D` is self-sufficient
 export AbstractLattice

--- a/src/api/builders.jl
+++ b/src/api/builders.jl
@@ -74,5 +74,4 @@ dice(L::Int, M::Int=L; kw...) = build_lattice(Dice, L, M; kw...)
 
 Shortcut for `build_lattice(ShastrySutherland, L, M; kw...)`.
 """
-shastry_sutherland(L::Int, M::Int=L; kw...) =
-    build_lattice(ShastrySutherland, L, M; kw...)
+shastry_sutherland(L::Int, M::Int=L; kw...) = build_lattice(ShastrySutherland, L, M; kw...)

--- a/src/api/builders.jl
+++ b/src/api/builders.jl
@@ -1,0 +1,78 @@
+"""
+    Lattice2D convenience builders
+    ==============================
+
+This file defines a thin layer of one-liner builders that delegate to
+[`build_lattice`](@ref). They exist purely to make call sites read more
+naturally:
+
+```julia
+lat = honeycomb(6, 6; boundary = OpenAxis())
+# is exactly equivalent to
+lat = build_lattice(Honeycomb, 6, 6; boundary = OpenAxis())
+```
+
+Every builder accepts the same keyword arguments as `build_lattice`
+(`boundary`, `indexing`, `layout`) and returns the same `Lattice` value
+— no behaviour is added or hidden.
+
+The second linear extent defaults to the first, so `square(8)` builds
+an `8 × 8` sample.
+"""
+
+"""
+    square(L::Int, M::Int = L; kw...) -> Lattice
+
+Shortcut for `build_lattice(Square, L, M; kw...)`.
+"""
+square(L::Int, M::Int=L; kw...) = build_lattice(Square, L, M; kw...)
+
+"""
+    triangular(L::Int, M::Int = L; kw...) -> Lattice
+
+Shortcut for `build_lattice(Triangular, L, M; kw...)`.
+"""
+triangular(L::Int, M::Int=L; kw...) = build_lattice(Triangular, L, M; kw...)
+
+"""
+    honeycomb(L::Int, M::Int = L; kw...) -> Lattice
+
+Shortcut for `build_lattice(Honeycomb, L, M; kw...)`.
+"""
+honeycomb(L::Int, M::Int=L; kw...) = build_lattice(Honeycomb, L, M; kw...)
+
+"""
+    kagome(L::Int, M::Int = L; kw...) -> Lattice
+
+Shortcut for `build_lattice(Kagome, L, M; kw...)`.
+"""
+kagome(L::Int, M::Int=L; kw...) = build_lattice(Kagome, L, M; kw...)
+
+"""
+    lieb(L::Int, M::Int = L; kw...) -> Lattice
+
+Shortcut for `build_lattice(Lieb, L, M; kw...)`.
+"""
+lieb(L::Int, M::Int=L; kw...) = build_lattice(Lieb, L, M; kw...)
+
+"""
+    union_jack(L::Int, M::Int = L; kw...) -> Lattice
+
+Shortcut for `build_lattice(UnionJack, L, M; kw...)`.
+"""
+union_jack(L::Int, M::Int=L; kw...) = build_lattice(UnionJack, L, M; kw...)
+
+"""
+    dice(L::Int, M::Int = L; kw...) -> Lattice
+
+Shortcut for `build_lattice(Dice, L, M; kw...)`.
+"""
+dice(L::Int, M::Int=L; kw...) = build_lattice(Dice, L, M; kw...)
+
+"""
+    shastry_sutherland(L::Int, M::Int = L; kw...) -> Lattice
+
+Shortcut for `build_lattice(ShastrySutherland, L, M; kw...)`.
+"""
+shastry_sutherland(L::Int, M::Int=L; kw...) =
+    build_lattice(ShastrySutherland, L, M; kw...)

--- a/test/api/test_builders.jl
+++ b/test/api/test_builders.jl
@@ -1,0 +1,62 @@
+@testset "Convenience builders" begin
+    # (builder, Topology, num_sublattices) — covers all 8 shipped topologies.
+    cases = [
+        (square, Square, 1),
+        (triangular, Triangular, 1),
+        (honeycomb, Honeycomb, 2),
+        (kagome, Kagome, 3),
+        (lieb, Lieb, 3),
+        (union_jack, UnionJack, 2),
+        (dice, Dice, 3),
+        (shastry_sutherland, ShastrySutherland, 4),
+    ]
+
+    @testset "covers every shipped topology" begin
+        # The set of topologies wired through the convenience layer must
+        # exactly match `AVAILABLE_LATTICES` so that adding a new topology
+        # to the package without a builder fails this test.
+        @test Set(c[2] for c in cases) == Set(AVAILABLE_LATTICES)
+    end
+
+    @testset "default M = L: $(nameof(builder))" for (builder, Topology, nsub) in cases
+        L = 4
+        lat = builder(L)
+        @test lat isa Lattice{Topology}
+        @test num_sublattices(lat) == nsub
+        @test num_sites(lat) == L * L * nsub
+        # Default boundary is fully periodic on both axes.
+        @test periodicity(lat) isa Periodic
+    end
+
+    @testset "explicit M ≠ L: $(nameof(builder))" for (builder, Topology, nsub) in cases
+        L, M = 3, 5
+        lat = builder(L, M)
+        @test lat isa Lattice{Topology}
+        @test num_sites(lat) == L * M * nsub
+    end
+
+    @testset "kw forwarding: $(nameof(builder))" for (builder, Topology, _) in cases
+        # `boundary` and `layout` keywords must be passed through to
+        # `build_lattice` unchanged.
+        lat = builder(3, 3; boundary=OpenAxis(), layout=UniformLayout(XYSite()))
+        ref = build_lattice(
+            Topology, 3, 3; boundary=OpenAxis(), layout=UniformLayout(XYSite())
+        )
+        @test lat isa Lattice{Topology}
+        @test num_sites(lat) == num_sites(ref)
+        @test site_type(lat, 1) === XYSite()
+        @test boundary(lat) == boundary(ref)
+    end
+
+    @testset "delegation equivalence: $(nameof(builder))" for (builder, Topology, _) in
+                                                              cases
+        # The shortcut and the long form must produce lattices with the
+        # same observable topology / size / connectivity.
+        lat = builder(4, 4)
+        ref = build_lattice(Topology, 4, 4)
+        @test lat isa Lattice{Topology}
+        @test num_sites(lat) == num_sites(ref)
+        @test num_sublattices(lat) == num_sublattices(ref)
+        @test count(_ -> true, bonds(lat)) == count(_ -> true, bonds(ref))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ const FIG_LAT = joinpath(FIG_BASE, "lattice")
 const PATHS = Dict(:geometry => joinpath(FIG_LAT, "geometry"))
 mkpath.(values(PATHS))
 
-const dirs = ["core", "lattices", "utils"]
+const dirs = ["core", "lattices", "utils", "api"]
 
 @testset "tests" begin
     test_args = copy(ARGS)


### PR DESCRIPTION
## Summary

- Add one-line shortcuts under `src/api/builders.jl` for every topology shipped by Lattice2D: `square`, `triangular`, `honeycomb`, `kagome`, `lieb`, `union_jack`, `dice`, `shastry_sutherland`. Each is a 1-3 line wrapper around `build_lattice` — `square(L, M=L; kw...) = build_lattice(Square, L, M; kw...)` — so call sites read as `honeycomb(6; boundary=OpenAxis())` instead of `build_lattice(Honeycomb, 6, 6; boundary=OpenAxis())`.
- `src/Lattice2D.jl` includes the new file and exports the 8 lowercase names; the existing `build_lattice` API and all upper-case topology singletons are unchanged.
- `test/runtests.jl` now also walks `test/api/`, with `test/api/test_builders.jl` exercising default `M = L`, explicit `M ≠ L`, keyword forwarding (`boundary`, `layout`), and delegation equivalence for every topology. A `Set` check against `AVAILABLE_LATTICES` ensures a future topology can't be added without a matching builder.

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (4425 tests + Aqua).
- [x] `square(4)` and `build_lattice(Square, 4, 4)` produce equivalent lattices (topology / sites / bonds).
- [x] `honeycomb(3, 3; boundary=OpenAxis(), layout=UniformLayout(XYSite()))` propagates kwargs to `build_lattice`.
- [x] All 8 shipped topologies are covered by builders and validated by tests.