### PR TITLE
feat: lattice structural predicates API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.10"
+version = "0.3.11"
 authors = ["souta shimozono"]
 
 [deps]

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -114,6 +114,7 @@ include("core/lattice.jl")
 include("core/cache.jl")
 include("core/element_api.jl")
 include("core/constructor.jl")
+include("api/predicates.jl")
 include("utils/iterator.jl")
 include("api/builders.jl")
 
@@ -217,6 +218,9 @@ export Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, Uni
 
 # Convenience builders (thin wrappers around `build_lattice`)
 export square, triangular, honeycomb, kagome, lieb, union_jack, dice, shastry_sutherland
+
+# Structural predicates (`src/api/predicates.jl`)
+export coordination_number, mean_coordination, bond_distances, shells
 
 # Re-exports from LatticeCore so `using Lattice2D` is self-sufficient
 export AbstractLattice

--- a/src/api/predicates.jl
+++ b/src/api/predicates.jl
@@ -1,0 +1,143 @@
+"""
+    Lattice2D structural predicates
+    ===============================
+
+This file groups one-shot helpers that report structural / graph-theoretic
+properties of a [`Lattice`](@ref) without touching its construction. They
+are pure functions of the lattice value and its declared connectivity, and
+they delegate to existing primitives ([`neighbors`](@ref), [`bonds`](@ref),
+[`num_sites`](@ref)) so any future change to those primitives is reflected
+here automatically.
+
+The helpers are intentionally cheap to write call sites for — common
+sanity checks ("is this bipartite?", "what is the mean coordination of
+this sample?", "give me the first three neighbour shells") collapse to a
+single call.
+"""
+
+# ---- is_bipartite ---------------------------------------------------
+#
+# Implementation moved here from `core/lattice.jl` to keep all
+# structural-predicate methods in one file. The signature and behaviour
+# are unchanged: BFS 2-colouring on the declared adjacency, returning
+# `false` on the first odd cycle.
+
+"""
+    is_bipartite(lat::Lattice) -> Bool
+
+Return `true` iff the declared adjacency graph of `lat` is bipartite,
+i.e. its sites admit a 2-colouring such that every bond connects
+different colours.
+
+Implemented as a BFS 2-colouring over [`neighbors`](@ref), starting a
+fresh BFS from each unvisited site so disconnected components are
+handled. `O(num_sites + num_bonds)`.
+"""
+function LatticeCore.is_bipartite(lat::Lattice)
+    N = num_sites(lat)
+    colors = zeros(Int, N)
+    for i in 1:N
+        colors[i] == 0 || continue
+        colors[i] = 1
+        queue = [i]
+        while !isempty(queue)
+            u = popfirst!(queue)
+            for v in neighbors(lat, u)
+                if colors[v] == 0
+                    colors[v] = -colors[u]
+                    push!(queue, v)
+                elseif colors[v] == colors[u]
+                    return false
+                end
+            end
+        end
+    end
+    return true
+end
+
+# ---- coordination number --------------------------------------------
+
+"""
+    coordination_number(lat::Lattice, i::Int) -> Int
+
+Degree of site `i` in the declared adjacency graph of `lat` (number of
+distinct neighbours, no double-counting). For PBC samples on uniform
+lattices this matches the textbook coordination number (Square = 4,
+Triangular = 6, Honeycomb = 3, Kagome = 4, ...). For OBC samples it
+returns the local degree, which is smaller at the boundary.
+"""
+coordination_number(lat::Lattice, i::Int) = length(neighbors(lat, i))
+
+"""
+    coordination_number(lat::Lattice) -> Vector{Int}
+
+Per-site degrees, in site-index order. Length `num_sites(lat)`.
+"""
+function coordination_number(lat::Lattice)
+    N = num_sites(lat)
+    out = Vector{Int}(undef, N)
+    @inbounds for i in 1:N
+        out[i] = coordination_number(lat, i)
+    end
+    return out
+end
+
+"""
+    mean_coordination(lat::Lattice) -> Float64
+
+Average coordination number across all sites of `lat`. For periodic
+uniform lattices this equals the bulk coordination number; for samples
+with open boundaries it is strictly smaller.
+"""
+function mean_coordination(lat::Lattice)
+    N = num_sites(lat)
+    N == 0 && return 0.0
+    s = 0
+    @inbounds for i in 1:N
+        s += coordination_number(lat, i)
+    end
+    return s / N
+end
+
+# ---- bond distances -------------------------------------------------
+
+"""
+    bond_distances(lat::Lattice) -> Vector{Float64}
+
+Euclidean length of every bond returned by [`bonds`](@ref), in the
+same order. Lengths are not deduplicated, so the multiset of distances
+encodes both the bond-type spectrum and the bond multiplicity.
+"""
+function bond_distances(lat::Lattice)
+    bs = bonds(lat)
+    out = Vector{Float64}(undef, length(bs))
+    @inbounds for k in eachindex(bs)
+        out[k] = Float64(norm(bs[k].vector))
+    end
+    return out
+end
+
+# ---- shells ---------------------------------------------------------
+
+"""
+    shells(lat::Lattice, i::Int; n_shells::Int = 3) -> Vector{Vector{Int}}
+
+Return the first `n_shells` geometric neighbour shells of site `i` as
+a list of site-index vectors. Each entry corresponds to one Euclidean
+distance class, in increasing order; the `k`-th entry is exactly
+`neighbors(lat, i; shell = k)`.
+
+Trailing empty shells (e.g. on a small OBC sample where the requested
+shell count exceeds the geometric reach) are returned as empty
+vectors, so the result always has length `n_shells`.
+
+`n_shells` must be `≥ 1`.
+"""
+function shells(lat::Lattice, i::Int; n_shells::Int=3)
+    n_shells ≥ 1 || throw(ArgumentError("n_shells must be ≥ 1, got $n_shells"))
+    out = Vector{Vector{Int}}(undef, n_shells)
+    @inbounds for k in 1:n_shells
+        out[k] = neighbors(lat, i; shell=k)
+    end
+    return out
+end

--- a/src/core/constructor.jl
+++ b/src/core/constructor.jl
@@ -69,7 +69,7 @@ end
 """
     sublattice_layout(Topology, Lx, Ly, types; indexing = RowMajor())
 
-Convenience constructor for a [`SublatticeLayout`](@ref) that matches
+Convenience constructor for a `SublatticeLayout` that matches
 the geometric sublattice structure of an `Lx × Ly` lattice of the
 given `Topology`.
 

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -65,7 +65,7 @@ num_bonds(lat::Lattice) = num_elements(lat, BondCenter())
 
 Convenience alias for `num_elements(lat, PlaquetteCenter())`.
 Returns 0 for topologies whose unit cell declares no
-[`PlaquetteRule`](@ref) (currently this is just `Dice` — wait, now
+`PlaquetteRule` (currently this is just `Dice` — wait, now
 it is not; every shipped topology has a plaquette list as of Iter 6).
 """
 num_plaquettes(lat::Lattice) = num_elements(lat, PlaquetteCenter())

--- a/src/core/lattice.jl
+++ b/src/core/lattice.jl
@@ -122,7 +122,7 @@ LatticeCore.size_trait(lat::Lattice) = FiniteSize((lat.Lx, lat.Ly))
 """
     Step{T}
 
-Internal, concretely-typed record returned by [`_connection_steps`](@ref):
+Internal, concretely-typed record returned by `_connection_steps`:
 the result of resolving a unit-cell `Connection` against the sample
 boundary. Fields:
 
@@ -501,8 +501,8 @@ end
 """
     to_lattice(lat::Lattice, coord::RealSpace) → LatticeCoord{2}
 
-Inverse of [`to_real`](@ref): map a real-space point back to the
-nearest [`LatticeCoord`](@ref) on `lat`. The implementation inverts
+Inverse of `to_real`: map a real-space point back to the
+nearest `LatticeCoord` on `lat`. The implementation inverts
 the basis matrix `A = [a1 a2]` once per call (`SMatrix{2,2}`, so the
 inverse is non-allocating), subtracts each candidate sublattice
 offset, and picks the `(cell, sublattice)` triple whose rounded cell
@@ -515,7 +515,7 @@ cell is returned as-is even when it falls outside `1:L`; callers that
 need an in-sample guarantee should validate the result against
 `(Lx, Ly)`.
 
-Together with [`to_real`](@ref) this satisfies
+Together with `to_real` this satisfies
 `to_lattice(lat, to_real(lat, c)) == c` for every in-sample
 `LatticeCoord` and every shipped topology.
 """

--- a/src/core/lattice.jl
+++ b/src/core/lattice.jl
@@ -441,28 +441,11 @@ end
 # `core/element_api.jl`, powered by the cached plaquette vector.
 
 # ---- Graph / topology traits ----------------------------------------
-
-function LatticeCore.is_bipartite(lat::Lattice)
-    N = num_sites(lat)
-    colors = zeros(Int, N)
-    for i in 1:N
-        colors[i] == 0 || continue
-        colors[i] = 1
-        queue = [i]
-        while !isempty(queue)
-            u = popfirst!(queue)
-            for v in neighbors(lat, u)
-                if colors[v] == 0
-                    colors[v] = -colors[u]
-                    push!(queue, v)
-                elseif colors[v] == colors[u]
-                    return false
-                end
-            end
-        end
-    end
-    return true
-end
+#
+# `LatticeCore.is_bipartite(lat::Lattice)` lives in
+# `src/api/predicates.jl` alongside the other structural-predicate
+# helpers (`coordination_number`, `mean_coordination`,
+# `bond_distances`, `shells`).
 
 function LatticeCore.periodicity(lat::Lattice)
     return all(!(ax isa OpenAxis) for ax in lat.boundary.axes) ? Periodic() : Aperiodic()

--- a/src/core/topology.jl
+++ b/src/core/topology.jl
@@ -5,7 +5,7 @@ Abstract supertype for 2D lattice topologies (Square, Triangular,
 Honeycomb, ...). Each concrete subtype is a singleton that acts as
 a dispatch key for [`get_unit_cell`](@ref), and, through
 `TopologyTrait` in LatticeCore, as the `topology(lat)` value of the
-resulting [`PeriodicLattice2D`](@ref).
+resulting [`Lattice`](@ref).
 """
 abstract type AbstractTopology{D} end
 
@@ -118,7 +118,7 @@ end
     get_plaquette_rules(::Type{T}) where {T <: AbstractTopology}
         → Vector{PlaquetteRule}
 
-Introspection helper that returns the list of [`PlaquetteRule`](@ref)
+Introspection helper that returns the list of `PlaquetteRule`
 templates declared in topology `T`'s unit cell. Equivalent to
 `get_unit_cell(T).plaquettes`, but communicates intent ("I only want
 the plaquette rules, not the full unit cell") and returns an empty

--- a/test/api/test_predicates.jl
+++ b/test/api/test_predicates.jl
@@ -1,0 +1,117 @@
+using LinearAlgebra: norm
+
+@testset "lattice predicates" begin
+    @testset "is_bipartite" begin
+        # Bipartite topologies (PBC, even Lx/Ly so the colouring closes)
+        @test is_bipartite(build_lattice(Square, 4, 4)) == true
+        @test is_bipartite(build_lattice(Honeycomb, 4, 4)) == true
+        @test is_bipartite(build_lattice(Honeycomb, 6, 6)) == true
+        @test is_bipartite(build_lattice(Lieb, 4, 4)) == true
+        @test is_bipartite(build_lattice(Dice, 4, 4)) == true
+
+        # Non-bipartite topologies
+        @test is_bipartite(build_lattice(Triangular, 4, 4)) == false
+        @test is_bipartite(build_lattice(Triangular, 6, 6)) == false
+        @test is_bipartite(build_lattice(Kagome, 4, 4)) == false
+
+        # Square with an odd-cycle wraparound (PBC, odd Lx)
+        @test is_bipartite(build_lattice(Square, 3, 4)) == false
+        # OBC removes the wraparound, restoring bipartiteness
+        @test is_bipartite(build_lattice(Square, 3, 3; boundary=OpenAxis())) == true
+    end
+
+    @testset "coordination_number — bulk values, PBC" begin
+        # Bulk coordination on uniform lattices (PBC: all sites equivalent
+        # for Bravais; sublattice lattices have one number per sublattice
+        # but share the same set, which we summarise via `unique` here).
+        @test all(==(4), coordination_number(build_lattice(Square, 6, 6)))
+        @test all(==(6), coordination_number(build_lattice(Triangular, 6, 6)))
+        @test all(==(3), coordination_number(build_lattice(Honeycomb, 4, 4)))
+        @test all(==(4), coordination_number(build_lattice(Kagome, 4, 4)))
+
+        # Single-site form agrees with the vector form
+        lat = build_lattice(Square, 5, 5)
+        v = coordination_number(lat)
+        @test length(v) == num_sites(lat)
+        @test v[1] == coordination_number(lat, 1)
+        @test v[end] == coordination_number(lat, num_sites(lat))
+    end
+
+    @testset "coordination_number — OBC drops at the boundary" begin
+        lat = build_lattice(Square, 4, 4; boundary=OpenAxis())
+        v = coordination_number(lat)
+        # Corners have 2 neighbours, edges 3, interior 4.
+        @test 2 in v
+        @test 3 in v
+        @test 4 in v
+        @test minimum(v) == 2
+        @test maximum(v) == 4
+    end
+
+    @testset "mean_coordination" begin
+        # PBC: mean equals the bulk coordination.
+        @test mean_coordination(build_lattice(Square, 6, 6)) ≈ 4.0
+        @test mean_coordination(build_lattice(Triangular, 6, 6)) ≈ 6.0
+        @test mean_coordination(build_lattice(Honeycomb, 4, 4)) ≈ 3.0
+        @test mean_coordination(build_lattice(Kagome, 4, 4)) ≈ 4.0
+
+        # OBC: strictly below the bulk value.
+        lat_obc = build_lattice(Square, 4, 4; boundary=OpenAxis())
+        @test mean_coordination(lat_obc) < 4.0
+
+        # Consistency with the vector form.
+        v = coordination_number(lat_obc)
+        @test mean_coordination(lat_obc) ≈ sum(v) / length(v)
+    end
+
+    @testset "bond_distances" begin
+        lat = build_lattice(Square, 4, 4)
+        d = bond_distances(lat)
+        @test length(d) == length(bonds(lat))
+        # Square NN bond length is 1.
+        @test all(x -> isapprox(x, 1.0; atol=1e-12), d)
+
+        # Honeycomb has a single NN distance (1/√3 in our convention).
+        lat_h = build_lattice(Honeycomb, 4, 4)
+        dh = bond_distances(lat_h)
+        @test length(dh) == length(bonds(lat_h))
+        @test all(x -> isapprox(x, dh[1]; atol=1e-10), dh)
+
+        # Cross-check against the underlying Bond.vector.
+        for (b, x) in zip(bonds(lat_h), dh)
+            @test x ≈ Float64(norm(b.vector))
+        end
+    end
+
+    @testset "shells: agrees with neighbors(...; shell=k)" begin
+        lat = build_lattice(Triangular, 6, 6)
+        sh = shells(lat, 1; n_shells=3)
+        @test length(sh) == 3
+        @test sort(sh[1]) == sort(neighbors(lat, 1; shell=1))
+        @test sort(sh[2]) == sort(neighbors(lat, 1; shell=2))
+        @test sort(sh[3]) == sort(neighbors(lat, 1; shell=3))
+        # Shells are mutually disjoint.
+        @test isempty(intersect(Set(sh[1]), Set(sh[2])))
+        @test isempty(intersect(Set(sh[1]), Set(sh[3])))
+        @test isempty(intersect(Set(sh[2]), Set(sh[3])))
+    end
+
+    @testset "shells: default n_shells = 3" begin
+        lat = build_lattice(Square, 6, 6)
+        @test length(shells(lat, 1)) == 3
+    end
+
+    @testset "shells: trailing empty for over-deep request on small OBC" begin
+        lat = build_lattice(Square, 3, 3; boundary=OpenAxis())
+        sh = shells(lat, 1; n_shells=10)
+        @test length(sh) == 10
+        # The deepest shells must be empty on a 3×3 OBC sample.
+        @test isempty(sh[end])
+    end
+
+    @testset "shells: n_shells must be ≥ 1" begin
+        lat = build_lattice(Square, 3, 3)
+        @test_throws ArgumentError shells(lat, 1; n_shells=0)
+        @test_throws ArgumentError shells(lat, 1; n_shells=-1)
+    end
+end


### PR DESCRIPTION
## Summary

- Add `src/api/predicates.jl` grouping structural / graph-theoretic
  helpers for `Lattice`: `is_bipartite` (moved from `core/lattice.jl`,
  same BFS 2-colouring), `coordination_number(lat[, i])`,
  `mean_coordination(lat)`, `bond_distances(lat)`, and
  `shells(lat, i; n_shells=3)` (first `n_shells` geometric shells
  agreeing with `neighbors(lat, i; shell=k)`).
- Wire `src/api/predicates.jl` into `src/Lattice2D.jl` (include +
  exports for the four new helpers; `is_bipartite` continues to be
  re-exported from LatticeCore unchanged), and add `test/api/` to the
  test-runner directory list.
- New `test/api/test_predicates.jl` covers bulk coordination
  (Square=4, Triangular=6, Honeycomb=3, Kagome=4), OBC
  corner/edge/interior degrees on Square, bipartiteness on
  Square/Honeycomb/Lieb/Dice and non-bipartiteness on
  Triangular/Kagome, `bond_distances` matching `Bond.vector` norms,
  and `shells` agreeing with `neighbors(...; shell=k)` on Triangular
  including disjointness and trailing-empty behaviour on small OBC.

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` (4404 unit tests
      pass + Aqua suite passes).
- [x] `is_bipartite(square)` / `is_bipartite(triangular)` /
      `is_bipartite(honeycomb)` return the expected
      `true`/`false`/`true`.
- [x] Bulk coordination numbers match textbook values on Square /
      Triangular / Honeycomb / Kagome.
- [x] `shells(lat, i; n_shells=3)` is element-wise consistent with
      `neighbors(lat, i; shell=k)` on Triangular.