### PR TITLE
docs: resolve LatticeCore re-export @ref cross-references (#68)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.3.12"
+version = "0.3.13"
 authors = ["souta shimozono"]
 
 [deps]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Lattice2D = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
+LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
 using Lattice2D
+using LatticeCore
 using Documenter
 
 # Run the feature figure generator script automatically before building docs
@@ -8,8 +9,16 @@ include(joinpath(@__DIR__, "src", "generate_features.jl"))
 # ドキュメントを生成する
 makedocs(;
     sitename="Lattice2D.jl",
+    # Only Lattice2D is in `modules` (drives the missing-docs check). LatticeCore
+    # symbols are surfaced via the `@autodocs Modules = [LatticeCore]` block in
+    # latticecore.md purely so their `@ref` cross-references resolve (issue #68);
+    # we intentionally do not require *every* LatticeCore docstring to be present.
     modules=[Lattice2D],
-    pages=["Home" => "index.md", "Gallery" => "Gallery.md"],
+    pages=[
+        "Home" => "index.md",
+        "Gallery" => "Gallery.md",
+        "LatticeCore API" => "latticecore.md",
+    ],
 )
 
 deploydocs(; repo="github.com/sotashimozono/Lattice2D.jl.git")

--- a/docs/src/latticecore.md
+++ b/docs/src/latticecore.md
@@ -1,0 +1,23 @@
+# LatticeCore API
+
+`Lattice2D` builds on [LatticeCore.jl](https://github.com/sotashimozono/LatticeCore.jl),
+which defines the abstract lattice vocabulary (the `AbstractLattice` hierarchy,
+`Bond`, boundary-condition singletons, indexing strategies, site types, …). These
+symbols are re-exported by `Lattice2D`, so `using Lattice2D` alone is enough to
+reach them.
+
+They are documented here so that the `@ref` cross-references inside `Lattice2D`
+docstrings resolve to a real target (see issue #68).
+
+```@autodocs
+Modules = [LatticeCore]
+# Skip the plotting/diffraction stubs: their docstrings reference the
+# `LatticeCorePlotsExt` package-extension module, which is not documented in
+# this doc set (the concrete methods live in the extension). Lattice2D does
+# not re-export these anyway — its own visualisation lives in Lattice2DPlotsExt.
+Filter = obj -> try
+    nameof(obj) ∉ (:plot_lattice, :plot_bonds!, :plot_sites!, :diffraction_pattern)
+catch
+    true
+end
+```

--- a/ext/Lattice2DFFTWExt.jl
+++ b/ext/Lattice2DFFTWExt.jl
@@ -61,17 +61,17 @@ Lattice2DFFTWExt
 # `LatticeCoreFFTWExt._structure_factor_fft` unchanged.
 
 function LatticeCore._has_known_grid(lat::Lattice2D.Lattice{Lattice2D.Square})
-    _is_rowmajor_periodic(lat)
+    return _is_rowmajor_periodic(lat)
 end
 function LatticeCore._has_known_grid(lat::Lattice2D.Lattice{Lattice2D.Triangular})
-    _is_rowmajor_periodic(lat)
+    return _is_rowmajor_periodic(lat)
 end
 
 function LatticeCore._reshape_state(::Lattice2D.Lattice{Lattice2D.Square}, state, dims)
-    reshape(state, dims)
+    return reshape(state, dims)
 end
 function LatticeCore._reshape_state(::Lattice2D.Lattice{Lattice2D.Triangular}, state, dims)
-    reshape(state, dims)
+    return reshape(state, dims)
 end
 
 # ---- Multi-sublattice override --------------------------------------

--- a/src/disorder/dilution.jl
+++ b/src/disorder/dilution.jl
@@ -352,7 +352,7 @@ function Base.show(io::IO, lat::DilutedLattice)
     Nbase = num_sites(lat.base)
     Nact = num_sites(lat)
     nkill = length(lat.killed_bonds)
-    print(
+    return print(
         io,
         "DilutedLattice over $(typeof(lat.base).name.name): " *
         "$(Nact) / $(Nbase) sites active, $(nkill) explicit bond removals",

--- a/src/utils/iterator.jl
+++ b/src/utils/iterator.jl
@@ -16,7 +16,7 @@ end
 function Base.show(io::IO, lat::Lattice{Topo}) where {Topo}
     bc_summary = join([string(typeof(ax).name.name) for ax in lat.boundary.axes], ", ")
     bipartite_str = is_bipartite(lat) ? "bipartite" : "not bipartite"
-    print(
+    return print(
         io,
         "\n" *
         "Lattice Shape: $(Topo)\n" *

--- a/test/core/test_structure_factor_fft.jl
+++ b/test/core/test_structure_factor_fft.jl
@@ -11,7 +11,7 @@ using StaticArrays
 # vanish off `k_target` (mod reciprocal-lattice vectors) and equal
 # `Nsites` at `k_target`, so `S(k_target) = Nsites`.
 function _plane_wave_state(lat, k_target)
-    [cis(dot(k_target, position(lat, i))) for i in 1:num_sites(lat)]
+    return [cis(dot(k_target, position(lat, i))) for i in 1:num_sites(lat)]
 end
 
 @testset "structure_factor FFT path (Lattice2DFFTWExt)" begin


### PR DESCRIPTION
## Summary
The Documentation workflow was failing on every push to `main` with a `cross_references` error: `@autodocs Modules = [Lattice2D]` on the home page could not resolve the `@ref` links in Lattice2D docstrings that target **re-exported LatticeCore symbols** (`neighbors`, `bonds`, `num_sites`, `to_real`, `LatticeCoord`, `PlaquetteRule`, …). Those docstrings live in the LatticeCore module and were never emitted into the built doc set, so the refs had no target.

## Fix
- Add a dedicated **"LatticeCore API"** reference page (`docs/src/latticecore.md`) documenting the LatticeCore surface via `@autodocs Modules = [LatticeCore]`, so every such `@ref` resolves.
- Home page stays clean — still `@autodocs Modules = [Lattice2D]`.
- Filter out the plotting/diffraction stubs (`plot_lattice`, `plot_bonds!`, `plot_sites!`, `diffraction_pattern`) from that page: their docstrings reference the `LatticeCorePlotsExt` extension module (not documented here, not re-exported by Lattice2D).
- `makedocs(modules = [Lattice2D])` unchanged, so the missing-docs check does not demand every LatticeCore docstring.
- `docs/Project.toml` gains `LatticeCore` so `using LatticeCore` resolves in `make.jl`.

This supersedes the code-span workaround approach (#66) — links now function instead of being inert code spans.

## Verification
Built locally with the exact CI command:
```
julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
julia --project=docs docs/make.jl
```
→ builds green, no `cross_references` and no `missing_docs` errors (only the benign "cannot detect deploy env" warning that is expected outside CI).

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)