### PR TITLE
Implement the LatticeCore scaling interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["souta shimozono"]
 
 [deps]
@@ -20,7 +20,7 @@ Lattice2DPlotsExt = "Plots"
 [compat]
 Aqua = "0.8"
 FFTW = "1"
-LatticeCore = "0.12"
+LatticeCore = "0.12.1"
 LinearAlgebra = "1.10"
 Plots = "1"
 Random = "1.10"

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -119,6 +119,7 @@ include("utils/iterator.jl")
 include("api/builders.jl")
 include("api/dual.jl")
 include("api/symmetry.jl")
+include("api/scaling.jl")
 include("disorder/dilution.jl")
 
 # ---- Plots-extension stubs ------------------------------------------

--- a/src/api/scaling.jl
+++ b/src/api/scaling.jl
@@ -1,0 +1,112 @@
+# Scale changes for Bravais-family lattices: the LatticeCore scaling interface.
+#
+# A `Lattice` is fully described by `(Topo, Lx, Ly, boundary, indexing, layout)`, so a scale step is
+# just a change of `(Lx, Ly)` with everything else carried over. The one thing that cannot always be
+# carried is the layout: a layout that stores data per *site* is sized to the old lattice.
+
+# One step doubles the per-axis cell counts. Halving is available whenever the counts allow it, which
+# `rescale` checks rather than rounding.
+LatticeCore.scaling_rule(::Lattice) = LinearScaling(2)
+
+# A layout may be transported to a lattice of a different size only if it carries no per-site data.
+# `UniformLayout` stores one site type; `SublatticeLayout` stores one per sublattice — both are
+# properties of the topology, not of the size. Anything else (e.g. an explicit per-site table) is
+# sized to the lattice it was built for and must not be silently reused.
+_size_independent_layout(::UniformLayout) = true
+_size_independent_layout(::SublatticeLayout) = true
+_size_independent_layout(::AbstractSiteLayout) = false
+
+function _rebuild(lat::Lattice{Topo,T}, Lx::Int, Ly::Int) where {Topo,T}
+    _size_independent_layout(lat.layout) || throw(ArgumentError(
+        "cannot rescale a lattice whose layout carries per-site data " *
+        "($(typeof(lat.layout))): it is sized to the current $(lat.Lx)×$(lat.Ly) lattice. " *
+        "Rebuild the layout for the target size and construct the lattice directly."
+    ))
+    return Lattice{Topo,T}(Lx, Ly, lat.boundary, lat.indexing, lat.layout, Ref{Any}(nothing))
+end
+
+"""
+    rescale(lat::Lattice, k::Integer = 1) -> Lattice
+
+The same lattice `k` scale steps larger: `(Lx, Ly)` are multiplied by `factor^k`, where `factor`
+comes from [`scaling_rule`](@ref). Topology, boundary condition, indexing and layout are carried
+over unchanged.
+
+`k = 0` returns `lat`. Negative `k` steps *down*, and requires both `Lx` and `Ly` to be divisible by
+`factor^|k|` — a lattice that cannot be halved exactly raises rather than rounding, since a silently
+rounded size would corrupt any sequence built on it.
+
+```jldoctest
+julia> using Lattice2D, LatticeCore
+
+julia> lat = build_lattice(Square, 2, 3);
+
+julia> l2 = rescale(lat, 2);
+
+julia> (l2.Lx, l2.Ly)
+(8, 12)
+
+julia> num_sites.(size_sequence(lat, 2))
+3-element Vector{Int64}:
+  6
+ 24
+ 96
+```
+"""
+function LatticeCore.rescale(lat::Lattice, k::Integer=1)
+    k == 0 && return lat
+    f = LatticeCore.scaling_rule(lat).factor
+    if k > 0
+        m = f^k
+        return _rebuild(lat, lat.Lx * m, lat.Ly * m)
+    end
+    m = f^(-k)
+    (lat.Lx % m == 0 && lat.Ly % m == 0) || throw(ArgumentError(
+        "cannot step down $(-k) level(s): $(lat.Lx)×$(lat.Ly) is not divisible by $m"
+    ))
+    return _rebuild(lat, lat.Lx ÷ m, lat.Ly ÷ m)
+end
+
+"""
+    cell_partition(lat::Lattice, k::Integer = 1) -> Vector{Vector{Int}}
+
+Group the sites of `lat` by which unit cell of the lattice `k` steps *coarser* — that is, of
+`rescale(lat, -k)` — they fall into. Entry `c` lists the site indices of `lat` inside cell `c` of the
+coarser lattice, indexed with `lat`'s own [`AbstractIndexing`](@ref); together the groups partition
+`1:num_sites(lat)`.
+
+Each group holds `factor^k × factor^k` unit cells of `lat`, hence
+`factor^(2k) * num_sublattices(lat)` sites. Requires `Lx` and `Ly` to be divisible by `factor^k`,
+for the same reason `rescale` does.
+
+```jldoctest
+julia> using Lattice2D, LatticeCore
+
+julia> groups = cell_partition(build_lattice(Square, 4, 4), 1);
+
+julia> length(groups), length(first(groups))
+(4, 4)
+
+julia> sort(reduce(vcat, groups)) == 1:16
+true
+```
+"""
+function LatticeCore.cell_partition(lat::Lattice, k::Integer=1)
+    k >= 1 || throw(ArgumentError("cell_partition needs k ≥ 1 (a coarser lattice); got k = $k"))
+    f = LatticeCore.scaling_rule(lat).factor
+    m = f^k
+    (lat.Lx % m == 0 && lat.Ly % m == 0) || throw(ArgumentError(
+        "cannot coarsen by $k level(s): $(lat.Lx)×$(lat.Ly) is not divisible by $m"
+    ))
+    nsub = num_sublattices(lat)
+    cdims = (lat.Lx ÷ m, lat.Ly ÷ m)
+    groups = [Int[] for _ in 1:prod(cdims)]
+    for i in 1:num_sites(lat)
+        lc = lattice_coord(lat.indexing, (lat.Lx, lat.Ly), nsub, i)
+        gx = (lc.cell[1] - 1) ÷ m + 1
+        gy = (lc.cell[2] - 1) ÷ m + 1
+        g = site_index(lat.indexing, cdims, 1, LatticeCoord((gx, gy), 1))
+        push!(groups[g], i)
+    end
+    return groups
+end

--- a/src/api/scaling.jl
+++ b/src/api/scaling.jl
@@ -17,12 +17,16 @@ _size_independent_layout(::SublatticeLayout) = true
 _size_independent_layout(::AbstractSiteLayout) = false
 
 function _rebuild(lat::Lattice{Topo,T}, Lx::Int, Ly::Int) where {Topo,T}
-    _size_independent_layout(lat.layout) || throw(ArgumentError(
-        "cannot rescale a lattice whose layout carries per-site data " *
-        "($(typeof(lat.layout))): it is sized to the current $(lat.Lx)×$(lat.Ly) lattice. " *
-        "Rebuild the layout for the target size and construct the lattice directly."
-    ))
-    return Lattice{Topo,T}(Lx, Ly, lat.boundary, lat.indexing, lat.layout, Ref{Any}(nothing))
+    _size_independent_layout(lat.layout) || throw(
+        ArgumentError(
+            "cannot rescale a lattice whose layout carries per-site data " *
+            "($(typeof(lat.layout))): it is sized to the current $(lat.Lx)×$(lat.Ly) lattice. " *
+            "Rebuild the layout for the target size and construct the lattice directly.",
+        ),
+    )
+    return Lattice{Topo,T}(
+        Lx, Ly, lat.boundary, lat.indexing, lat.layout, Ref{Any}(nothing)
+    )
 end
 
 """
@@ -61,9 +65,11 @@ function LatticeCore.rescale(lat::Lattice, k::Integer=1)
         return _rebuild(lat, lat.Lx * m, lat.Ly * m)
     end
     m = f^(-k)
-    (lat.Lx % m == 0 && lat.Ly % m == 0) || throw(ArgumentError(
-        "cannot step down $(-k) level(s): $(lat.Lx)×$(lat.Ly) is not divisible by $m"
-    ))
+    (lat.Lx % m == 0 && lat.Ly % m == 0) || throw(
+        ArgumentError(
+            "cannot step down $(-k) level(s): $(lat.Lx)×$(lat.Ly) is not divisible by $m",
+        ),
+    )
     return _rebuild(lat, lat.Lx ÷ m, lat.Ly ÷ m)
 end
 
@@ -92,12 +98,15 @@ true
 ```
 """
 function LatticeCore.cell_partition(lat::Lattice, k::Integer=1)
-    k >= 1 || throw(ArgumentError("cell_partition needs k ≥ 1 (a coarser lattice); got k = $k"))
+    k >= 1 ||
+        throw(ArgumentError("cell_partition needs k ≥ 1 (a coarser lattice); got k = $k"))
     f = LatticeCore.scaling_rule(lat).factor
     m = f^k
-    (lat.Lx % m == 0 && lat.Ly % m == 0) || throw(ArgumentError(
-        "cannot coarsen by $k level(s): $(lat.Lx)×$(lat.Ly) is not divisible by $m"
-    ))
+    (lat.Lx % m == 0 && lat.Ly % m == 0) || throw(
+        ArgumentError(
+            "cannot coarsen by $k level(s): $(lat.Lx)×$(lat.Ly) is not divisible by $m"
+        ),
+    )
     nsub = num_sublattices(lat)
     cdims = (lat.Lx ÷ m, lat.Ly ÷ m)
     groups = [Int[] for _ in 1:prod(cdims)]

--- a/test/api/test_scaling.jl
+++ b/test/api/test_scaling.jl
@@ -79,10 +79,12 @@ end
     # how sites are numbered — only the labels may permute.
     ref = nothing
     for idx in (RowMajor(), ColMajor(), Snake())
-        lat = build_lattice(Square, 4, 4; indexing = idx)
+        lat = build_lattice(Square, 4, 4; indexing=idx)
         groups = cell_partition(lat, 1)
         # convert each group to the set of lattice coordinates it covers
-        as_coords = Set(Set(lattice_coord(idx, (4, 4), 1, i).cell for i in g) for g in groups)
+        as_coords = Set(
+            Set(lattice_coord(idx, (4, 4), 1, i).cell for i in g) for g in groups
+        )
         ref === nothing ? (ref = as_coords) : (@test as_coords == ref)
     end
 end

--- a/test/api/test_scaling.jl
+++ b/test/api/test_scaling.jl
@@ -1,0 +1,88 @@
+using Lattice2D
+using LatticeCore
+using Test
+
+@testset "scaling_rule" begin
+    for T in AVAILABLE_LATTICES
+        @test scaling_rule(build_lattice(T, 2, 2)) === LinearScaling(2)
+    end
+end
+
+@testset "rescale multiplies the cell counts" begin
+    lat = build_lattice(Square, 2, 3)
+    @test rescale(lat, 0) === lat
+    @test (rescale(lat).Lx, rescale(lat).Ly) == (4, 6)
+    @test (rescale(lat, 2).Lx, rescale(lat, 2).Ly) == (8, 12)
+
+    # topology, boundary, indexing and layout survive the step
+    up = rescale(lat, 2)
+    @test up isa typeof(lat)
+    @test up.boundary === lat.boundary
+    @test up.indexing === lat.indexing
+    @test up.layout === lat.layout
+
+    # site counts scale as factor^(2k)
+    @test num_sites(rescale(lat, 1)) == 4 * num_sites(lat)
+    @test num_sites(rescale(lat, 2)) == 16 * num_sites(lat)
+end
+
+@testset "rescale down, and refusing to round" begin
+    lat = build_lattice(Square, 8, 4)
+    @test (rescale(lat, -1).Lx, rescale(lat, -1).Ly) == (4, 2)
+    @test (rescale(lat, -2).Lx, rescale(lat, -2).Ly) == (2, 1)
+    # 8x4 cannot be halved three times: an inexact step raises rather than rounding
+    @test_throws ArgumentError rescale(lat, -3)
+    @test_throws ArgumentError rescale(build_lattice(Square, 3, 3), -1)
+end
+
+@testset "size_sequence over every topology" begin
+    for T in AVAILABLE_LATTICES
+        lat = build_lattice(T, 2, 2)
+        seq = size_sequence(lat, 2)
+        @test length(seq) == 3
+        @test num_sites(seq[1]) == num_sites(lat)
+        @test num_sites(seq[2]) == 4 * num_sites(lat)
+        @test num_sites(seq[3]) == 16 * num_sites(lat)
+        # a multi-sublattice topology keeps its sublattice count under rescaling
+        @test num_sublattices(seq[3]) == num_sublattices(lat)
+    end
+end
+
+@testset "cell_partition really partitions" begin
+    for T in AVAILABLE_LATTICES, (Lx, Ly) in ((4, 4), (8, 4))
+        lat = build_lattice(T, Lx, Ly)
+        n = num_sites(lat)
+        nsub = num_sublattices(lat)
+        for k in 1:2
+            (Lx % 2^k == 0 && Ly % 2^k == 0) || continue
+            groups = cell_partition(lat, k)
+            # covers every site exactly once
+            @test sort(reduce(vcat, groups)) == collect(1:n)
+            # one group per cell of the coarser lattice
+            coarse = rescale(lat, -k)
+            @test length(groups) == coarse.Lx * coarse.Ly
+            # each group holds factor^(2k) cells' worth of sites
+            @test all(g -> length(g) == 4^k * nsub, groups)
+        end
+    end
+end
+
+@testset "cell_partition argument checks" begin
+    lat = build_lattice(Square, 4, 4)
+    @test_throws ArgumentError cell_partition(lat, 0)
+    @test_throws ArgumentError cell_partition(lat, -1)
+    @test_throws ArgumentError cell_partition(lat, 3)   # 4 is not divisible by 8
+end
+
+@testset "indexing schemes agree on the grouping" begin
+    # the partition is a geometric statement, so the groups must contain the same SITES regardless of
+    # how sites are numbered — only the labels may permute.
+    ref = nothing
+    for idx in (RowMajor(), ColMajor(), Snake())
+        lat = build_lattice(Square, 4, 4; indexing = idx)
+        groups = cell_partition(lat, 1)
+        # convert each group to the set of lattice coordinates it covers
+        as_coords = Set(Set(lattice_coord(idx, (4, 4), 1, i).cell for i in g) for g in groups)
+        ref === nothing ? (ref = as_coords) : (@test as_coords == ref)
+    end
+end


### PR DESCRIPTION
Implements the `LatticeCore` scaling interface (`scaling_rule` / `rescale` / `cell_partition`) added in LatticeCore.jl#80, so a routine that sweeps a quantity against system size can be written once against `LatticeCore` and applied here without knowing that this family is parameterized by `(Lx, Ly)`.

Verified against `LatticeCore` v0.12.1 resolved **from the registry** — the same condition CI runs under — with the full suite green:

```
Test Summary: | Pass  Total   Time
tests         | 8831   8831  36.6s
     Testing Lattice2D tests passed
```

(8831 includes the 162 added here. `Aqua` passes, including `test_persistent_tasks`, which re-resolves from the registry.)

## What it does

A `Lattice` is fully described by `(Topo, Lx, Ly, boundary, indexing, layout)`, so a scale step is just a change of `(Lx, Ly)` with everything else carried over.

```julia
lat = build_lattice(Kagome, 2, 2)
scaling_rule(lat)                  # LinearScaling(2)
num_sites.(size_sequence(lat, 2))  # 12, 48, 192
cell_partition(build_lattice(Square, 4, 4), 1)   # 4 groups of 4 sites
```

`cell_partition(lat, k)` groups the sites of `lat` by which cell of the lattice `k` steps *coarser* they fall into, using `lat`'s own indexing. Each group holds `factor^(2k)` unit cells.

## Two decisions worth flagging

**Stepping down refuses to round.** `rescale(lat, -k)` requires `Lx` and `Ly` to be divisible by `factor^k` and raises otherwise. A silently rounded size would corrupt any sequence built on it, and the failure would show up much later as a scaling curve that does not quite line up.

**Not every layout can be transported.** `UniformLayout` and `SublatticeLayout` store properties of the topology, not of the size, so they carry over unchanged. A layout holding per-site data is sized to the lattice it was built for; reusing it silently would be wrong, so it is refused with a message naming the layout type and the current dimensions.

## Tests

162 tests over all eight topologies:

- the trait, and cell/site counts under rescaling (`factor^(2k)`)
- `boundary`, `indexing`, `layout` survive a step; `num_sublattices` is preserved
- inexact down-steps raise (`8×4` cannot be halved three times; `3×3` cannot be halved at all)
- `size_sequence` for every topology
- `cell_partition` really partitions `1:num_sites` — covers, no repeats, correct group count and group size
- **the grouping is indexing-invariant**: `RowMajor`, `ColMajor` and `Snake` produce the same *sets of sites*, only permuting the labels. The partition is a geometric statement, so this is the property that should hold rather than index equality.

## Scope

- Additive only; no existing behaviour changes.
- `LatticeCore` compat `"0.12"` → `"0.12.1"`, version `0.5.1` → `0.5.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
