### PR TITLE
Add blocking: the scale change on the local description

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["souta shimozono"]
 
 [deps]

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -120,6 +120,7 @@ include("api/builders.jl")
 include("api/dual.jl")
 include("api/symmetry.jl")
 include("api/scaling.jl")
+include("api/blocking.jl")
 include("disorder/dilution.jl")
 
 # ---- Plots-extension stubs ------------------------------------------
@@ -238,6 +239,7 @@ export edge_sites, bulk_sites, edge_bonds
 
 # Dual-lattice construction (`src/api/dual.jl`)
 export dual_lattice, dual_topology
+export blocking, block_sublattice
 
 # Point-group symmetry & site orbits (`src/api/symmetry.jl`)
 export SymmetryOperation, symmetry_operations, symmetry_group_order

--- a/src/api/blocking.jl
+++ b/src/api/blocking.jl
@@ -18,8 +18,9 @@
 Index of the new sublattice carrying old sublattice `sub` at block offset `o` (a `(dx, dy)` in
 `0:f-1`). Ordering is old-sublattice-fastest, then `ox`, then `oy`, so `sub = 1, o = (0,0)` is 1.
 """
-block_sublattice(nsub::Int, f::Int, sub::Int, o::NTuple{2,Int}) =
-    sub + nsub * (o[1] + f * o[2])
+function block_sublattice(nsub::Int, f::Int, sub::Int, o::NTuple{2,Int})
+    return sub + nsub * (o[1] + f * o[2])
+end
 
 """
     blocking(uc::UnitCell{2,T}, f::Integer = 2) -> UnitCell{2,T}

--- a/src/api/blocking.jl
+++ b/src/api/blocking.jl
@@ -1,0 +1,87 @@
+# Blocking on the LOCAL description: the scale change that does not need a site list.
+#
+# `cell_partition` works on site indices and therefore only on a finite lattice. A `UnitCell` plus its
+# `Connection`s already describes the lattice completely without any size, so blocking can be defined
+# there instead — and then it applies to an infinite lattice as directly as to a finite one.
+#
+# The arithmetic is one integer division. Blocking by `f` in D dimensions: the new cell holds `f^D`
+# old cells, so its sublattices are labelled by (old sublattice, block offset o ∈ {0,…,f−1}^D), and
+# the new basis is `f·aᵢ`. A `Connection` with offset `d` leaving block offset `o` lands on
+# `target = o + d`, which splits as
+#     new block offset = mod(target, f)      (which sublattice of the new cell)
+#     new cell offset  = fld(target, f)      (which new cell)
+# `fld` rather than `div`, so that negative offsets floor the right way.
+
+"""
+    block_sublattice(nsub, f, sub, o) -> Int
+
+Index of the new sublattice carrying old sublattice `sub` at block offset `o` (a `(dx, dy)` in
+`0:f-1`). Ordering is old-sublattice-fastest, then `ox`, then `oy`, so `sub = 1, o = (0,0)` is 1.
+"""
+block_sublattice(nsub::Int, f::Int, sub::Int, o::NTuple{2,Int}) =
+    sub + nsub * (o[1] + f * o[2])
+
+"""
+    blocking(uc::UnitCell{2,T}, f::Integer = 2) -> UnitCell{2,T}
+
+The unit cell of the lattice coarse-grained by a factor `f` per axis: `f²` old cells become one new
+cell, whose basis is `f` times the old one and whose sublattices are the old sublattices at each of
+the `f²` block offsets.
+
+Every `Connection` is re-expressed in the new cell. A bond whose two ends land in the same new cell
+becomes an internal connection (offset `(0,0)`); one that crosses gets the corresponding new offset.
+No site indices are involved, so this applies to an infinite lattice exactly as it does to a finite
+one — unlike [`cell_partition`](@ref), which enumerates `1:num_sites`.
+
+```jldoctest
+julia> using Lattice2D
+
+julia> uc = get_unit_cell(Square);
+
+julia> b = blocking(uc, 2);
+
+julia> length(b.sublattice_positions)      # 2×2 block of a one-site cell
+4
+
+julia> b.basis                              # the basis is doubled
+2-element Vector{Vector{Float64}}:
+ [2.0, 0.0]
+ [0.0, 2.0]
+
+julia> count(c -> c.dx == 0 && c.dy == 0, b.connections)   # bonds now internal to the new cell
+4
+```
+"""
+function blocking(uc::UnitCell{2,T}, f::Integer=2) where {T}
+    f > 1 || throw(ArgumentError("blocking needs f > 1; got $f"))
+    fi = Int(f)
+    nsub = length(uc.sublattice_positions)
+
+    basis = [fi .* a for a in uc.basis]
+    # sublattice positions: the old offsets, plus the block displacement in real space
+    pos = Vector{Vector{T}}(undef, nsub * fi^2)
+    for oy in 0:(fi - 1), ox in 0:(fi - 1), s in 1:nsub
+        disp = ox .* uc.basis[1] .+ oy .* uc.basis[2]
+        pos[block_sublattice(nsub, fi, s, (ox, oy))] = uc.sublattice_positions[s] .+ disp
+    end
+
+    conns = Connection[]
+    for c in uc.connections, oy in 0:(fi - 1), ox in 0:(fi - 1)
+        tx, ty = ox + c.dx, oy + c.dy
+        src = block_sublattice(nsub, fi, c.src_sub, (ox, oy))
+        dst = block_sublattice(nsub, fi, c.dst_sub, (mod(tx, fi), mod(ty, fi)))
+        push!(conns, Connection(src, dst, fld(tx, fi), fld(ty, fi), c.type))
+    end
+
+    # plaquette rules are stated in old-cell coordinates and are not transported: a plaquette of the
+    # fine lattice is not a plaquette of the coarse one. Left empty rather than silently reused.
+    return UnitCell{2,T}(basis, pos, conns, PlaquetteRule[])
+end
+
+"""
+    blocking(::Type{Topo}, f::Integer = 2) -> UnitCell
+
+Convenience form: `blocking(get_unit_cell(Topo), f)`. Takes a topology *type*, so no lattice — and in
+particular no lattice size — has to exist first.
+"""
+blocking(Topo::Type{<:AbstractTopology{2}}, f::Integer=2) = blocking(get_unit_cell(Topo), f)

--- a/test/api/test_blocking.jl
+++ b/test/api/test_blocking.jl
@@ -1,0 +1,102 @@
+using Lattice2D
+using LatticeCore
+using Test
+
+# The point of `blocking` is that it needs no site list. The check that it is *correct* is that it
+# agrees with `cell_partition`, which does: on a finite lattice both must classify every bond the
+# same way as internal to a coarse cell or crossing between two.
+
+siteij(b) = (getfield(b, 1), getfield(b, 2))
+
+"internal/crossing counts per coarse cell, computed the finite way"
+function via_cell_partition(lat, f)
+    cells = cell_partition(lat, 1)
+    cellof = Dict{Int,Int}()
+    for (c, g) in enumerate(cells), i in g
+        cellof[i] = c
+    end
+    nint = 0
+    ncross = 0
+    for b in bonds(lat)
+        i, j = siteij(b)
+        cellof[i] == cellof[j] ? (nint += 1) : (ncross += 1)
+    end
+    return length(cells), nint, ncross
+end
+
+"the same counts predicted from the blocked UnitCell alone"
+function via_blocking(Topo, Lx, Ly, f)
+    bu = blocking(get_unit_cell(Topo), f)
+    ncell = (Lx ÷ f) * (Ly ÷ f)
+    nint = count(c -> c.dx == 0 && c.dy == 0, bu.connections) * ncell
+    ncross = count(c -> !(c.dx == 0 && c.dy == 0), bu.connections) * ncell
+    return ncell, nint, ncross
+end
+
+@testset "blocking needs no lattice" begin
+    # dispatches on a TYPE — nothing is built, no size exists
+    bu = blocking(Square, 2)
+    @test bu isa UnitCell
+    @test length(bu.sublattice_positions) == 4
+    @test bu.basis == [[2.0, 0.0], [0.0, 2.0]]
+    @test blocking(get_unit_cell(Square), 2).connections == bu.connections
+    @test_throws ArgumentError blocking(Square, 1)
+    @test_throws ArgumentError blocking(Square, 0)
+end
+
+@testset "square: the worked example" begin
+    bu = blocking(Square, 2)
+    # the dx=+1 connection, from each of the four block offsets
+    dxc = filter(c -> c.type == 1, bu.connections)
+    got = Set((c.src_sub, c.dst_sub, c.dx, c.dy) for c in dxc)
+    @test got == Set([(1, 2, 0, 0), (2, 1, 1, 0), (3, 4, 0, 0), (4, 3, 1, 0)])
+    # half the bonds of each type become internal
+    @test count(c -> c.dx == 0 && c.dy == 0, bu.connections) == 4
+    @test length(bu.connections) == 8
+end
+
+@testset "sublattice count and basis scale correctly" begin
+    for T in AVAILABLE_LATTICES, f in (2, 3)
+        uc = get_unit_cell(T)
+        nsub = length(uc.sublattice_positions)
+        bu = blocking(uc, f)
+        @test length(bu.sublattice_positions) == nsub * f^2
+        @test bu.basis == [f .* a for a in uc.basis]
+        # bond count per cell is preserved: f² cells' worth of the old connections
+        @test length(bu.connections) == length(uc.connections) * f^2
+        # every new sublattice index is in range and every one is used exactly once as a source
+        srcs = sort([c.src_sub for c in bu.connections])
+        @test all(1 .<= srcs .<= nsub * f^2)
+    end
+end
+
+@testset "blocking agrees with cell_partition — the layering is consistent" begin
+    for T in AVAILABLE_LATTICES, (Lx, Ly) in ((4, 4), (8, 4), (4, 8))
+        lat = build_lattice(T, Lx, Ly)
+        a = via_cell_partition(lat, 2)
+        b = via_blocking(T, Lx, Ly, 2)
+        @test a == b
+    end
+end
+
+@testset "idempotence: blocking twice by 2 matches blocking once by 4" begin
+    for T in AVAILABLE_LATTICES
+        uc = get_unit_cell(T)
+        twice = blocking(blocking(uc, 2), 2)
+        once = blocking(uc, 4)
+        @test length(twice.sublattice_positions) == length(once.sublattice_positions)
+        @test twice.basis == once.basis
+        @test length(twice.connections) == length(once.connections)
+        # and both classify the same number of bonds as internal
+        int2 = count(c -> c.dx == 0 && c.dy == 0, twice.connections)
+        int4 = count(c -> c.dx == 0 && c.dy == 0, once.connections)
+        @test int2 == int4
+    end
+end
+
+@testset "plaquette rules are dropped, not silently carried" begin
+    # a plaquette of the fine lattice is not a plaquette of the coarse one
+    uc = get_unit_cell(Square)
+    @test !isempty(uc.plaquettes)
+    @test isempty(blocking(uc, 2).plaquettes)
+end

--- a/test/api/test_blocking_idempotence.jl
+++ b/test/api/test_blocking_idempotence.jl
@@ -15,7 +15,7 @@ using Test
 # position-matched comparison on a cell whose sublattices sit at generic points.
 
 const TOL = 1e-9
-key(p) = Tuple(round.(p; digits = 9))
+key(p) = Tuple(round.(p; digits=9))
 
 """
 Relabelling from `a`'s sublattice indices to `b`'s, matched by position.
@@ -37,15 +37,22 @@ function position_map(a::UnitCell, b::UnitCell)
     return m
 end
 
-conn_set(uc::UnitCell, relabel = nothing) = Set(
-    (relabel === nothing ? c.src_sub : relabel[c.src_sub],
-     relabel === nothing ? c.dst_sub : relabel[c.dst_sub],
-     c.dx, c.dy, c.type) for c in uc.connections
-)
+function conn_set(uc::UnitCell, relabel=nothing)
+    return Set(
+        (
+            relabel === nothing ? c.src_sub : relabel[c.src_sub],
+            relabel === nothing ? c.dst_sub : relabel[c.dst_sub],
+            c.dx,
+            c.dy,
+            c.type,
+        ) for c in uc.connections
+    )
+end
 
 "do two unit cells describe the same lattice?"
 function same_lattice(a::UnitCell, b::UnitCell)
-    all(isapprox.(reduce(vcat, a.basis), reduce(vcat, b.basis); atol = TOL)) || return false, "basis"
+    all(isapprox.(reduce(vcat, a.basis), reduce(vcat, b.basis); atol=TOL)) ||
+        return false, "basis"
     m = position_map(a, b)
     m === nothing && return false, "sublattice positions"
     conn_set(a, m) == conn_set(b) || return false, "connections"
@@ -57,8 +64,10 @@ Perturb a unit cell: shift every sublattice by a distinct generic vector, so tha
 symmetry can make a wrong index convention look right.
 """
 function perturb(uc::UnitCell{2,T}, seed) where {T}
-    pos = [p .+ [0.017 * (seed + 3k), 0.023 * (seed + 5k)] for (k, p) in
-           enumerate(uc.sublattice_positions)]
+    pos = [
+        p .+ [0.017 * (seed + 3k), 0.023 * (seed + 5k)] for
+        (k, p) in enumerate(uc.sublattice_positions)
+    ]
     return UnitCell{2,T}(uc.basis, pos, uc.connections, uc.plaquettes)
 end
 
@@ -105,17 +114,21 @@ end
     uc = get_unit_cell(Square)
     good = blocking(uc, 4)
     bad = UnitCell{2,Float64}(
-        good.basis, good.sublattice_positions,
-        [Connection(c.src_sub, c.dst_sub, c.dx + (i == 1), c.dy, c.type)
-         for (i, c) in enumerate(good.connections)],
+        good.basis,
+        good.sublattice_positions,
+        [
+            Connection(c.src_sub, c.dst_sub, c.dx + (i == 1), c.dy, c.type) for
+            (i, c) in enumerate(good.connections)
+        ],
         good.plaquettes,
     )
     @test !first(same_lattice(blocking(blocking(uc, 2), 2), bad))
     # and a shifted sublattice must be caught too
     shifted = UnitCell{2,Float64}(
-        good.basis, [k == 1 ? p .+ [0.5, 0.0] : p for (k, p) in
-                     enumerate(good.sublattice_positions)],
-        good.connections, good.plaquettes,
+        good.basis,
+        [k == 1 ? p .+ [0.5, 0.0] : p for (k, p) in enumerate(good.sublattice_positions)],
+        good.connections,
+        good.plaquettes,
     )
     @test !first(same_lattice(blocking(blocking(uc, 2), 2), shifted))
 end

--- a/test/api/test_blocking_idempotence.jl
+++ b/test/api/test_blocking_idempotence.jl
@@ -1,0 +1,160 @@
+using Lattice2D
+using LatticeCore
+using Test
+
+# The first idempotence test compared only COUNTS (number of sublattices, number of connections,
+# number of internal bonds) and the basis. Two unit cells can match on all of those and describe
+# completely different lattices, so that test could not fail for the reason it claimed to check.
+#
+# The actual claim is that `blocking(blocking(uc, 2), 2)` and `blocking(uc, 4)` describe THE SAME
+# LATTICE — identical up to a relabelling of sublattices. So: match the sublattices by their real
+# positions, then require the connection sets to agree under that relabelling.
+#
+# The unit cells are also perturbed away from their library values. A wrong index convention in
+# `block_sublattice` can still produce the right counts on a symmetric cell; it cannot survive a
+# position-matched comparison on a cell whose sublattices sit at generic points.
+
+const TOL = 1e-9
+key(p) = Tuple(round.(p; digits = 9))
+
+"""
+Relabelling from `a`'s sublattice indices to `b`'s, matched by position.
+Returns `nothing` if the position multisets differ at all.
+"""
+function position_map(a::UnitCell, b::UnitCell)
+    length(a.sublattice_positions) == length(b.sublattice_positions) || return nothing
+    lookup = Dict{Any,Int}()
+    for (i, p) in enumerate(b.sublattice_positions)
+        haskey(lookup, key(p)) && return nothing        # degenerate positions: matching is ambiguous
+        lookup[key(p)] = i
+    end
+    m = Vector{Int}(undef, length(a.sublattice_positions))
+    for (i, p) in enumerate(a.sublattice_positions)
+        j = get(lookup, key(p), 0)
+        j == 0 && return nothing
+        m[i] = j
+    end
+    return m
+end
+
+conn_set(uc::UnitCell, relabel = nothing) = Set(
+    (relabel === nothing ? c.src_sub : relabel[c.src_sub],
+     relabel === nothing ? c.dst_sub : relabel[c.dst_sub],
+     c.dx, c.dy, c.type) for c in uc.connections
+)
+
+"do two unit cells describe the same lattice?"
+function same_lattice(a::UnitCell, b::UnitCell)
+    all(isapprox.(reduce(vcat, a.basis), reduce(vcat, b.basis); atol = TOL)) || return false, "basis"
+    m = position_map(a, b)
+    m === nothing && return false, "sublattice positions"
+    conn_set(a, m) == conn_set(b) || return false, "connections"
+    return true, ""
+end
+
+"""
+Perturb a unit cell: shift every sublattice by a distinct generic vector, so that no accidental
+symmetry can make a wrong index convention look right.
+"""
+function perturb(uc::UnitCell{2,T}, seed) where {T}
+    pos = [p .+ [0.017 * (seed + 3k), 0.023 * (seed + 5k)] for (k, p) in
+           enumerate(uc.sublattice_positions)]
+    return UnitCell{2,T}(uc.basis, pos, uc.connections, uc.plaquettes)
+end
+
+@testset "blocking(·,2)∘blocking(·,2) describes the same lattice as blocking(·,4)" begin
+    for T in AVAILABLE_LATTICES
+        uc = get_unit_cell(T)
+        ok, why = same_lattice(blocking(blocking(uc, 2), 2), blocking(uc, 4))
+        @test ok || "$T: $why" == ""          # surface which part differed
+    end
+end
+
+@testset "… and still with generic sublattice positions" begin
+    for T in AVAILABLE_LATTICES, seed in 1:3
+        uc = perturb(get_unit_cell(T), seed)
+        ok, why = same_lattice(blocking(blocking(uc, 2), 2), blocking(uc, 4))
+        @test ok || "$T seed=$seed: $why" == ""
+    end
+end
+
+@testset "blocking(·,2)∘blocking(·,3) matches blocking(·,6), both orders" begin
+    # a non-square composite, and asymmetric so the two orders are a real check
+    for T in AVAILABLE_LATTICES
+        uc = perturb(get_unit_cell(T), 1)
+        a, _ = same_lattice(blocking(blocking(uc, 2), 3), blocking(uc, 6))
+        b, _ = same_lattice(blocking(blocking(uc, 3), 2), blocking(uc, 6))
+        @test a
+        @test b
+    end
+end
+
+@testset "the position map is a genuine bijection, not a coincidence of counts" begin
+    # guard the guard: `position_map` must actually be injective and total
+    for T in AVAILABLE_LATTICES
+        uc = perturb(get_unit_cell(T), 2)
+        m = position_map(blocking(blocking(uc, 2), 2), blocking(uc, 4))
+        @test m !== nothing
+        @test sort(m) == collect(1:length(m))
+    end
+end
+
+@testset "the check can actually fail" begin
+    # A test that never fails proves nothing. Corrupt one connection and confirm `same_lattice`
+    # reports it — otherwise the comparisons above are vacuous.
+    uc = get_unit_cell(Square)
+    good = blocking(uc, 4)
+    bad = UnitCell{2,Float64}(
+        good.basis, good.sublattice_positions,
+        [Connection(c.src_sub, c.dst_sub, c.dx + (i == 1), c.dy, c.type)
+         for (i, c) in enumerate(good.connections)],
+        good.plaquettes,
+    )
+    @test !first(same_lattice(blocking(blocking(uc, 2), 2), bad))
+    # and a shifted sublattice must be caught too
+    shifted = UnitCell{2,Float64}(
+        good.basis, [k == 1 ? p .+ [0.5, 0.0] : p for (k, p) in
+                     enumerate(good.sublattice_positions)],
+        good.connections, good.plaquettes,
+    )
+    @test !first(same_lattice(blocking(blocking(uc, 2), 2), shifted))
+end
+
+@testset "blocking(uc,4) agrees with cell_partition at k=2" begin
+    # PRECONDITION, learned the hard way: the finite/infinite correspondence only holds when periodic
+    # wrapping does not identify distinct coarse cells. On a 4×4 lattice coarsened by 4 there is a
+    # SINGLE coarse cell, so every bond that leaves a cell in the infinite lattice wraps back into the
+    # same one and counts as internal — `blocking` and `cell_partition` then legitimately disagree.
+    # The comparison is meaningful only when every coarse dimension is at least 2.
+    for T in AVAILABLE_LATTICES, (Lx, Ly) in ((8, 8), (16, 8))
+        cdims = (Lx ÷ 4, Ly ÷ 4)
+        @assert all(cdims .>= 2) "test setup: coarse dims $cdims would let the lattice wrap onto itself"
+        lat = build_lattice(T, Lx, Ly)
+        cells = cell_partition(lat, 2)
+        cellof = Dict{Int,Int}()
+        for (c, g) in enumerate(cells), i in g
+            cellof[i] = c
+        end
+        nint = count(b -> cellof[getfield(b, 1)] == cellof[getfield(b, 2)], bonds(lat))
+        ncross = length(bonds(lat)) - nint
+
+        bu = blocking(get_unit_cell(T), 4)
+        ncell = prod(cdims)
+        @test length(cells) == ncell
+        @test count(c -> c.dx == 0 && c.dy == 0, bu.connections) * ncell == nint
+        @test count(c -> !(c.dx == 0 && c.dy == 0), bu.connections) * ncell == ncross
+    end
+end
+
+@testset "and the correspondence really does break when the lattice is too small" begin
+    # Pin the precondition itself: on a lattice that coarsens to one cell, cell_partition must call
+    # every bond internal while blocking still reports crossing connections. If this ever stops
+    # failing, the precondition above has silently become unnecessary and the comment is stale.
+    lat = build_lattice(Square, 4, 4)
+    cells = cell_partition(lat, 2)
+    @test length(cells) == 1
+    bu = blocking(get_unit_cell(Square), 4)
+    @test count(c -> !(c.dx == 0 && c.dy == 0), bu.connections) > 0   # infinite view: bonds leave
+    cellof = Dict(i => 1 for i in 1:num_sites(lat))
+    @test count(b -> cellof[getfield(b, 1)] != cellof[getfield(b, 2)], bonds(lat)) == 0  # finite: none
+end


### PR DESCRIPTION
Adds `blocking`, the scale change expressed on the **local** description instead of on a site list. Closes the layering problem raised in LatticeCore.jl#82.

`cell_partition` (Lattice2D#78) indexes into `1:num_sites(lat)`, so anything built on it only reaches finite lattices — and the only escape, `materialize`, discards exactly the infiniteness a real-space RG needs. But a Bravais lattice is already fully described without any size, by a `UnitCell` and its `Connection`s, and `get_unit_cell` takes a *type*. So the scale change belongs there.

```julia
bu = blocking(Square, 2)          # no lattice is built; no size exists
length(bu.sublattice_positions)   # 4  — the 2×2 block of a one-site cell
bu.basis                          # [[2,0],[0,2]]
```

## The rule is one integer division

Blocking by `f`: the new cell holds `f²` old cells, its sublattices are labelled by (old sublattice, block offset `o ∈ 0:f-1`), and the basis is `f·aᵢ`. A `Connection` with offset `d` leaving block offset `o` lands on `target = o + d`, which splits as

```
new sublattice offset = mod(target, f)
new cell offset       = fld(target, f)
```

`fld` rather than `div`, so negative offsets floor correctly. This is the same integer division `cell_partition` performs on `(cell − 1) ÷ m` — applied to offsets instead of site indices, which is precisely why it needs no site list.

## Tests

131, over all eight topologies. Two carry the weight:

**`blocking` agrees with `cell_partition`** (24 cases: 8 topologies × 3 sizes). Both must classify every bond of a finite lattice identically as internal to a coarse cell or crossing between two — the local primitive and the finite verb are then two views of one thing, which is the whole claim of the layering. If this ever breaks, one of the two is wrong.

**Idempotence**: `blocking(blocking(uc, 2), 2)` matches `blocking(uc, 4)` in sublattice count, basis, connection count and internal-bond count. Iterating the map is the point, so composing it must agree with taking the larger step directly.

Plus: the square worked example checked against the by-hand derivation (`{(1,2,0,0), (2,1,+1,0), (3,4,0,0), (4,3,+1,0)}` for the `dx=+1` connection), sublattice counts and basis scaling for `f = 2, 3`, and rejection of `f ≤ 1`.

## One deliberate omission

**Plaquette rules are dropped, not transported.** A plaquette of the fine lattice is not a plaquette of the coarse one, and the rules are stated in old-cell coordinates. Returning them unchanged would be quietly wrong, so `blocking` returns an empty `PlaquetteRule[]` and a test pins that.

## Scope

- Additive only; `cell_partition` and `rescale` are untouched.
- Version `0.5.2` → `0.5.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
