### PR TITLE
Relabel main as 0.5.0 so the registry sequence can restart

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.5.3"
+version = "0.5.0"
 authors = ["souta shimozono"]
 
 [deps]


### PR DESCRIPTION
The registry has been stuck at **0.4.1 since 2026-07-11**, while `AutoRegister` reported success on every push. `Pkg.add("Lattice2D")` still resolves to 0.4.1, so none of the 0.5.x work — including `scaling_rule`/`rescale`/`cell_partition` (#78) and `blocking` (#79) — is reachable from outside.

## What actually happened

Version **0.5.0 never existed on main**. It was set inside `refactor/reexport-lc-regions` (`43154e8`, `9041172`), and the merge that landed (`b8b310f`) already carried 0.5.1. `AutoRegister` reads `Project.toml` at main's tip, so it never observed 0.5.0 and registered 0.5.1 directly on top of 0.4.1.

General's AutoMerge then refused it:

> Does not meet sequential version number guideline: version 0.5.1 skips over 0.5.0.

and 0.5.2 and 0.5.3 piled up behind it. Three registration PRs are open and stalled: [#160797](https://github.com/JuliaRegistries/General/pull/160797), [#161957](https://github.com/JuliaRegistries/General/pull/161957), [#161964](https://github.com/JuliaRegistries/General/pull/161964).

## Why not register the branch tip as 0.5.0

`9041172` branched from `05c5e8f`, *before* the point-group symmetry merge `d29e904`. It does not contain `SymmetryOperation`, `symmetry_operations`, `symmetry_orbits`, `site_orbit`, or the rotation/reflection predicates — all of which 0.4.1 already had.

Registering it would place a permanent functional regression into the public registry between 0.4.1 and 0.5.1, and registry entries cannot be withdrawn.

## What this PR does

Relabels main `0.5.3` → `0.5.0`. **The content is unchanged**; only the number moves. Since nothing after 0.4.1 was ever registered, this is what the current state should have been called. The registry then sees `0.4.1 → 0.5.0` — sequential — and AutoMerge proceeds without anyone having to approve a skipped version.

## Expected CI

**`VersionCheck` will fail, by design.** It enforces a strictly increasing version and this deliberately decreases one. It is not a required status check on `main`.

## Follow-up

1. Close the three stale General PRs as void, with the explanation above.
2. Versioning continues from 0.5.0 as normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
