### PR TITLE
feat: translation-cell motif + InfiniteLattice for the 2D catalogue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["souta shimozono"]
 
 [deps]
@@ -20,7 +20,7 @@ Lattice2DPlotsExt = "Plots"
 [compat]
 Aqua = "0.8"
 FFTW = "1"
-LatticeCore = "0.12.1"
+LatticeCore = "0.12.3"
 LinearAlgebra = "1.10"
 Plots = "1"
 Random = "1.10"

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -103,7 +103,19 @@ import LatticeCore:
     Plaquette,
     plaquettes,
     neighbor_plaquettes,
-    plaquette_center
+    plaquette_center,
+    InfiniteSize,
+    CellSite,
+    CellBond,
+    translation_vectors,
+    num_basis_sites,
+    basis_position,
+    cell_bonds,
+    site_orbits,
+    bond_orbits,
+    cell_position,
+    incident_cell_bonds,
+    neighbors_at
 
 # ---- Lattice2D source files -----------------------------------------
 
@@ -114,6 +126,7 @@ include("core/lattice.jl")
 include("core/cache.jl")
 include("core/element_api.jl")
 include("core/constructor.jl")
+include("core/translation_cell.jl")
 include("api/predicates.jl")
 include("utils/iterator.jl")
 include("api/builders.jl")
@@ -276,5 +289,12 @@ export num_elements, elements, element_position, element_positions
 export element_neighbors, incident
 export PlaquetteRule, Plaquette, plaquettes, neighbor_plaquettes, plaquette_center
 export materialize, require_finite
+
+# ---- Translation-cell (unit-cell motif) layer ----
+export InfiniteLattice
+export CellSite, CellBond
+export translation_vectors, num_basis_sites, basis_position, cell_bonds
+export site_orbits, bond_orbits
+export cell_position, incident_cell_bonds, neighbors_at
 
 end # module Lattice2D

--- a/src/core/translation_cell.jl
+++ b/src/core/translation_cell.jl
@@ -1,0 +1,179 @@
+# Translation-cell (unit-cell motif) layer for Lattice2D.
+#
+# Implements LatticeCore's translation-cell interface
+# (`translation_vectors`, `basis_position`, `cell_bonds`) on the finite
+# `Lattice{Topo,T}` by reading the topology's `get_unit_cell`, and adds
+# `InfiniteLattice{Topo,T}` — the thermodynamic-limit counterpart. With
+# those four methods the whole 2D catalogue gains LatticeCore's lazy
+# orbit accessors (`site_orbits`, `bond_orbits`, `cell_position`,
+# `neighbors_at`, `incident_cell_bonds`) for free, so a tensor network
+# can be placed one tensor per site/bond orbit and contracted along the
+# motif without materialising the lattice.
+#
+# The motif is exactly the topology's `UnitCell`: `sublattice_positions`
+# are the basis-site offsets and each `Connection(src, dst, dx, dy,
+# type)` is one undirected motif bond. Finiteness and boundary
+# conditions only change how that motif is tiled, not the motif itself —
+# so `Lattice` (finite) and `InfiniteLattice` share the same geometry
+# source and a downstream builder written against the orbit accessors
+# runs unchanged across both.
+
+# ---- Shared: UnitCell.Connection -> LatticeCore.CellBond -------------
+#
+# `build_lattice` tags emitted bonds `:type_N` from the integer
+# `Connection.type`; we mirror that convention here so a motif bond and
+# its instantiated `Bond` carry the same type symbol.
+@inline function _cell_bonds_from_unitcell(::Type{Topo}) where {Topo<:AbstractTopology{2}}
+    conns = get_unit_cell(Topo).connections
+    return [
+        CellBond(c.src_sub, c.dst_sub, (c.dx, c.dy), Symbol("type_", c.type)) for c in conns
+    ]
+end
+
+# ---- Finite Lattice: motif methods ----------------------------------
+#
+# `num_basis_sites` is not overridden: LatticeCore's default delegates
+# to `num_sublattices`, which `Lattice` already implements.
+
+LatticeCore.translation_vectors(lat::Lattice) = basis_vectors(lat)
+
+function LatticeCore.basis_position(lat::Lattice{Topo,T}, b::Int) where {Topo,T}
+    offs = _sub_offsets(Lattice{Topo,T})
+    1 <= b <= length(offs) ||
+        throw(ArgumentError("basis site $b out of range 1:$(length(offs)) for $(Topo)"))
+    return offs[b]
+end
+
+LatticeCore.cell_bonds(::Lattice{Topo}) where {Topo} = _cell_bonds_from_unitcell(Topo)
+
+# ---- InfiniteLattice: the thermodynamic-limit object ----------------
+
+"""
+    InfiniteLattice{Topo, T, L}(; T = Float64, layout = UniformLayout(IsingSite()))
+
+A truly infinite 2D lattice of topology `Topo` — the
+thermodynamic-limit counterpart of the finite [`Lattice`](@ref) under
+periodic boundary conditions. It carries no size (`size_trait` is
+`InfiniteSize`, [`num_sites`](@ref) throws) and is described by, and
+accessed through, its unit-cell motif:
+
+- `site_orbits` / `bond_orbits` — the finite fundamental domain (one
+  entry per sublattice / per `Connection` of `get_unit_cell(Topo)`);
+- `cell_position`, `neighbors_at`, `incident_cell_bonds` — on-demand
+  access to any [`CellSite`](@ref), computed without materialising the
+  lattice.
+
+If a finite sample is needed, [`materialize`](@ref) tiles the motif
+into a periodic [`Lattice`](@ref):
+
+```julia
+inf = InfiniteLattice(Honeycomb)
+fin = materialize(inf; dims = (8, 8))   # 8×8 PBC honeycomb Lattice
+```
+
+but the lazy accessors above never require it.
+
+# Example
+```julia
+inf = InfiniteLattice(Kagome)
+site_orbits(inf)                         # 1:3  (three sublattices)
+length(collect(bond_orbits(inf)))        # motif bond count
+neighbors_at(inf, CellSite((0, 0), 1))   # neighbours of basis-1 site
+```
+"""
+struct InfiniteLattice{Topo<:AbstractTopology{2},T<:AbstractFloat,L<:AbstractSiteLayout} <:
+       AbstractLattice{2,T}
+    layout::L
+end
+
+function InfiniteLattice(
+    ::Type{Topo};
+    T::Type{<:AbstractFloat}=Float64,
+    layout::AbstractSiteLayout=UniformLayout(IsingSite()),
+) where {Topo<:AbstractTopology{2}}
+    return InfiniteLattice{Topo,T,typeof(layout)}(layout)
+end
+
+# ---- Motif interface (same geometry source as the finite Lattice) ---
+
+function LatticeCore.translation_vectors(::InfiniteLattice{Topo,T}) where {Topo,T}
+    a1, a2 = get_unit_cell(Topo).basis
+    return SMatrix{2,2,T}(T(a1[1]), T(a1[2]), T(a2[1]), T(a2[2]))
+end
+
+function LatticeCore.num_sublattices(::InfiniteLattice{Topo}) where {Topo}
+    return length(get_unit_cell(Topo).sublattice_positions)
+end
+
+function LatticeCore.basis_position(::InfiniteLattice{Topo,T}, b::Int) where {Topo,T}
+    subs = get_unit_cell(Topo).sublattice_positions
+    1 <= b <= length(subs) ||
+        throw(ArgumentError("basis site $b out of range 1:$(length(subs)) for $(Topo)"))
+    p = subs[b]
+    return SVector{2,T}(T(p[1]), T(p[2]))
+end
+
+function LatticeCore.cell_bonds(::InfiniteLattice{Topo}) where {Topo}
+    return _cell_bonds_from_unitcell(Topo)
+end
+
+# ---- Size / traits --------------------------------------------------
+
+LatticeCore.size_trait(::InfiniteLattice) = InfiniteSize()
+LatticeCore.periodicity(::InfiniteLattice) = Periodic()
+LatticeCore.reciprocal_support(::InfiniteLattice) = HasReciprocal()
+LatticeCore.site_layout(l::InfiniteLattice) = l.layout
+
+function LatticeCore.topology(::InfiniteLattice{Topo}) where {Topo}
+    return TopologyTrait{topology_name(Topo())}()
+end
+
+# Conceptually the thermodynamic limit of full periodic boundaries.
+LatticeCore.boundary(::InfiniteLattice) = LatticeBoundary((PeriodicAxis(), PeriodicAxis()))
+
+# ---- Linear-index API is undefined for an infinite lattice ----------
+
+function LatticeCore.num_sites(::InfiniteLattice)
+    return throw(
+        DomainError(
+            InfiniteSize(),
+            "InfiniteLattice has no finite site count; use `site_orbits` for the " *
+            "unit-cell basis or `materialize(lat; dims)` for a finite sample",
+        ),
+    )
+end
+
+function LatticeCore.position(::InfiniteLattice, ::Int)
+    return throw(
+        DomainError(
+            InfiniteSize(),
+            "InfiniteLattice has no linear site index; address sites by `CellSite` " *
+            "and use `cell_position(lat, site)`",
+        ),
+    )
+end
+
+function LatticeCore.neighbors(::InfiniteLattice, ::Int)
+    return throw(
+        DomainError(
+            InfiniteSize(),
+            "InfiniteLattice has no linear site index; use `neighbors_at(lat, ::CellSite)`",
+        ),
+    )
+end
+
+# ---- Bridge: materialise into a finite periodic sample --------------
+
+"""
+    materialize(lat::InfiniteLattice{Topo}; dims::NTuple{2, Int}) → Lattice{Topo}
+
+Tile the motif into a `dims[1] × dims[2]` periodic [`Lattice`](@ref) of
+the same topology, carrying the infinite lattice's site layout. This is
+the optional infinite → finite bridge; the lazy translation-cell
+accessors do not require it.
+"""
+function LatticeCore.materialize(
+    lat::InfiniteLattice{Topo}; dims::NTuple{2,Int}
+) where {Topo}
+    return build_lattice(Topo, dims[1], dims[2]; boundary=PeriodicAxis(), layout=lat.layout)
+end

--- a/src/core/translation_cell.jl
+++ b/src/core/translation_cell.jl
@@ -23,11 +23,24 @@
 # `build_lattice` tags emitted bonds `:type_N` from the integer
 # `Connection.type`; we mirror that convention here so a motif bond and
 # its instantiated `Bond` carry the same type symbol.
-@inline function _cell_bonds_from_unitcell(::Type{Topo}) where {Topo<:AbstractTopology{2}}
+#
+# Cached `Topo -> Tuple{CellBond{2}...}` and reused by every
+# `cell_bonds` / `incident_cell_bonds` / `neighbors_at` call, mirroring
+# the `_SUB_OFFSETS_CACHE` / `_CONN_TYPE_SYMBOLS` discipline in
+# `lattice.jl` — these accessors are meant for hot tensor-network build
+# loops. An immutable tuple is returned so the shared value cannot be
+# mutated by a caller.
+const _CELL_BONDS_CACHE = IdDict{DataType,Any}()
+
+function _cell_bonds_from_unitcell(::Type{Topo}) where {Topo<:AbstractTopology{2}}
+    cached = get(_CELL_BONDS_CACHE, Topo, nothing)
+    cached === nothing || return cached::Tuple{Vararg{CellBond{2}}}
     conns = get_unit_cell(Topo).connections
-    return [
+    val = Tuple(
         CellBond(c.src_sub, c.dst_sub, (c.dx, c.dy), Symbol("type_", c.type)) for c in conns
-    ]
+    )
+    _CELL_BONDS_CACHE[Topo] = val
+    return val
 end
 
 # ---- Finite Lattice: motif methods ----------------------------------
@@ -49,7 +62,7 @@ LatticeCore.cell_bonds(::Lattice{Topo}) where {Topo} = _cell_bonds_from_unitcell
 # ---- InfiniteLattice: the thermodynamic-limit object ----------------
 
 """
-    InfiniteLattice{Topo, T, L}(; T = Float64, layout = UniformLayout(IsingSite()))
+    InfiniteLattice{Topo, T, L}(; layout = UniformLayout(IsingSite()))
 
 A truly infinite 2D lattice of topology `Topo` — the
 thermodynamic-limit counterpart of the finite [`Lattice`](@ref) under
@@ -73,6 +86,9 @@ fin = materialize(inf; dims = (8, 8))   # 8×8 PBC honeycomb Lattice
 
 but the lazy accessors above never require it.
 
+Positions use `Float64`, matching the finite [`Lattice`](@ref) produced
+by [`build_lattice`](@ref).
+
 # Example
 ```julia
 inf = InfiniteLattice(Kagome)
@@ -87,11 +103,9 @@ struct InfiniteLattice{Topo<:AbstractTopology{2},T<:AbstractFloat,L<:AbstractSit
 end
 
 function InfiniteLattice(
-    ::Type{Topo};
-    T::Type{<:AbstractFloat}=Float64,
-    layout::AbstractSiteLayout=UniformLayout(IsingSite()),
+    ::Type{Topo}; layout::AbstractSiteLayout=UniformLayout(IsingSite())
 ) where {Topo<:AbstractTopology{2}}
-    return InfiniteLattice{Topo,T,typeof(layout)}(layout)
+    return InfiniteLattice{Topo,Float64,typeof(layout)}(layout)
 end
 
 # ---- Motif interface (same geometry source as the finite Lattice) ---
@@ -130,6 +144,31 @@ end
 
 # Conceptually the thermodynamic limit of full periodic boundaries.
 LatticeCore.boundary(::InfiniteLattice) = LatticeBoundary((PeriodicAxis(), PeriodicAxis()))
+
+# `is_bipartite` is a topology-intrinsic property, so the infinite
+# lattice must agree with the finite one rather than fall through to the
+# generic `false` default. Reuse the finite BFS 2-colouring on an open
+# 6×6 patch: every motif offset spans at most ±1 cell, so the patch
+# contains the shortest cycle, and OBC avoids the boundary-wrap odd
+# cycles that a periodic sample could introduce — matching the infinite
+# graph.
+function LatticeCore.is_bipartite(::InfiniteLattice{Topo}) where {Topo}
+    return is_bipartite(build_lattice(Topo, 6, 6; boundary=OpenAxis()))
+end
+
+# There is no linear site index, so `sublattice(inf, i)` is undefined.
+# Throw the same way as `position` / `neighbors` / `num_sites` rather
+# than return the misleading generic default of `1`; a site's sublattice
+# is the `.basis` field of its `CellSite`.
+function LatticeCore.sublattice(::InfiniteLattice, ::Int)
+    return throw(
+        DomainError(
+            InfiniteSize(),
+            "InfiniteLattice has no linear site index; a site's sublattice is the " *
+            "`.basis` field of its `CellSite`",
+        ),
+    )
+end
 
 # ---- Linear-index API is undefined for an infinite lattice ----------
 

--- a/test/lattices/test_translation_cell.jl
+++ b/test/lattices/test_translation_cell.jl
@@ -7,12 +7,14 @@ const _TC_TOPOS = (
     Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
 )
 
-# Real-space displacement vectors from a finite interior site of
-# sublattice `b`, via the *independently implemented* `neighbor_bonds`
-# path. A 7×7 OBC sample guarantees a full-coordination interior site
-# for every sublattice (motif offsets span at most ±1 cell), and OBC
-# means the stored displacement is unwrapped.
-function _finite_neighbor_vecs(Topo, b)
+# (displacement vector, bond-type symbol) pairs from a finite interior
+# site of sublattice `b`, via the *independently implemented*
+# `neighbor_bonds` path (which derives its `:type_N` tag through the
+# separate `_conn_type_symbols` cache, not `_cell_bonds_from_unitcell`).
+# A 7×7 OBC sample guarantees a full-coordination interior site for
+# every sublattice (motif offsets span at most ±1 cell), and OBC means
+# the stored displacement is unwrapped.
+function _finite_neighbor_pairs(Topo, b)
     lat = build_lattice(Topo, 7, 7; boundary=OpenAxis())
     best_i, best_c = 0, -1
     for i in 1:num_sites(lat)
@@ -20,21 +22,26 @@ function _finite_neighbor_vecs(Topo, b)
         c = length(neighbor_bonds(lat, i))
         c > best_c && ((best_i, best_c) = (i, c))
     end
-    vecs = Set(round.(nb.vector; digits=6) for nb in neighbor_bonds(lat, best_i))
-    return vecs, best_c
+    pairs = Set(
+        (round.(nb.vector; digits=6), nb.type) for nb in neighbor_bonds(lat, best_i)
+    )
+    return pairs, best_c
 end
 
-# Same displacement set, but reconstructed purely from the motif via the
-# lazy accessors on the infinite lattice.
-function _motif_neighbor_vecs(Topo, b)
+# Same (vector, type) set, reconstructed purely from the motif via the
+# lazy accessors on the infinite lattice. Comparing types here — not
+# just displacements — catches a mangled `:type_N` mapping that the
+# geometry alone would miss.
+function _motif_neighbor_pairs(Topo, b)
     inf = InfiniteLattice(Topo)
     p_b = basis_position(inf, b)
     ib = incident_cell_bonds(inf, CellSite((0, 0), b))
-    vecs = Set(
-        round.(cell_position(inf, CellSite(Tuple(cb.offset), cb.dst)) .- p_b; digits=6) for
-        cb in ib
+    return Set(
+        (
+            round.(cell_position(inf, CellSite(Tuple(cb.offset), cb.dst)) .- p_b; digits=6),
+            cb.type,
+        ) for cb in ib
     )
-    return vecs
 end
 
 @testset "finite Lattice motif interface — all topologies" begin
@@ -56,17 +63,36 @@ end
     end
 end
 
-@testset "motif neighbours match the finite neighbor_bonds path" begin
+@testset "motif neighbours (vector + type) match the finite neighbor_bonds path" begin
     # The strong independent check: the coordination shell reconstructed
-    # from the unit-cell motif must equal the one the established finite
-    # neighbour code produces for an interior site.
+    # from the unit-cell motif — displacement AND bond type — must equal
+    # the one the established finite neighbour code produces for an
+    # interior site.
     for Topo in _TC_TOPOS
         for b in 1:num_sublattices(build_lattice(Topo, 2, 2))
-            finite_vecs, finite_c = _finite_neighbor_vecs(Topo, b)
-            motif_vecs = _motif_neighbor_vecs(Topo, b)
-            @test length(motif_vecs) == finite_c
-            @test motif_vecs == finite_vecs
+            finite_pairs, finite_c = _finite_neighbor_pairs(Topo, b)
+            motif_pairs = _motif_neighbor_pairs(Topo, b)
+            @test length(motif_pairs) == finite_c
+            @test motif_pairs == finite_pairs
         end
+    end
+end
+
+@testset "cell_bonds reproduces the raw UnitCell Connections" begin
+    # Independent of `_cell_bonds_from_unitcell`: rebuild the expected
+    # motif directly from each topology's raw `Connection` fields and
+    # diff. Catches a src/dst swap, a wrong offset, or a mangled type
+    # index that the geometry-only neighbour check could absorb.
+    for Topo in _TC_TOPOS
+        conns = get_unit_cell(Topo).connections
+        expected = Set(
+            (c.src_sub, c.dst_sub, (c.dx, c.dy), Symbol("type_", c.type)) for c in conns
+        )
+        got = Set(
+            (cb.src, cb.dst, Tuple(cb.offset), cb.type) for
+            cb in cell_bonds(InfiniteLattice(Topo))
+        )
+        @test got == expected
     end
 end
 
@@ -80,13 +106,19 @@ end
         @test_throws DomainError num_sites(inf)
         @test_throws DomainError position(inf, 1)
         @test_throws DomainError neighbors(inf, 1)
+        # No linear index ⇒ sublattice(i) must throw, not return 1.
+        @test_throws DomainError sublattice(inf, 1)
+        # Out-of-range basis fails loudly.
+        @test_throws ArgumentError basis_position(inf, num_basis_sites(inf) + 1)
 
         fin = build_lattice(Topo, 3, 3)
         @test collect(site_orbits(inf)) == collect(site_orbits(fin))
         @test translation_vectors(inf) == basis_vectors(fin)
-        # Same motif as the finite lattice (src, dst, offset, type).
-        key(cb) = (cb.src, cb.dst, cb.offset, cb.type)
-        @test Set(key.(cell_bonds(inf))) == Set(key.(cell_bonds(fin)))
+
+        # `is_bipartite` is topology-intrinsic: the infinite lattice must
+        # agree with a finite (PBC, even) sample — an independent path
+        # (OBC 6×6 BFS vs PBC 4×4 BFS).
+        @test is_bipartite(inf) == is_bipartite(build_lattice(Topo, 4, 4))
     end
 end
 
@@ -103,6 +135,29 @@ end
     @test site_type(inf2, 1) == XYSite()
     fin2 = materialize(inf2; dims=(2, 2))
     @test site_type(fin2, 1) == XYSite()
+end
+
+@testset "materialize — non-square dims, every topology" begin
+    # Non-square dims catch an Lx/Ly transposition in materialize; the
+    # loop covers the topologies the Honeycomb/Square cases above miss.
+    for Topo in _TC_TOPOS
+        nsub = num_basis_sites(InfiniteLattice(Topo))
+        fin = materialize(InfiniteLattice(Topo); dims=(3, 5))
+        @test fin isa Lattice
+        @test num_sites(fin) == 3 * 5 * nsub
+        @test periodicity(fin) == Periodic()
+    end
+end
+
+@testset "lazy accessors also work on the finite Lattice" begin
+    # The orbit accessors are generic over AbstractLattice, so they must
+    # dispatch on a finite `Lattice` too (not only InfiniteLattice).
+    lat = build_lattice(Square, 4, 4)
+    nb = neighbors_at(lat, CellSite((2, 2), 1))
+    @test length(nb) == 4
+    @test Set(n.cell .- SVector(2, 2) for n in nb) ==
+        Set(SVector.([(1, 0), (-1, 0), (0, 1), (0, -1)]))
+    @test length(collect(incident_cell_bonds(lat, CellSite((2, 2), 1)))) == 4
 end
 
 @testset "InfiniteLattice — lazy access is translation invariant" begin

--- a/test/lattices/test_translation_cell.jl
+++ b/test/lattices/test_translation_cell.jl
@@ -1,0 +1,124 @@
+using Lattice2D
+using Lattice2D: CellSite, CellBond
+using StaticArrays
+using Test
+
+const _TC_TOPOS = (
+    Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
+)
+
+# Real-space displacement vectors from a finite interior site of
+# sublattice `b`, via the *independently implemented* `neighbor_bonds`
+# path. A 7×7 OBC sample guarantees a full-coordination interior site
+# for every sublattice (motif offsets span at most ±1 cell), and OBC
+# means the stored displacement is unwrapped.
+function _finite_neighbor_vecs(Topo, b)
+    lat = build_lattice(Topo, 7, 7; boundary=OpenAxis())
+    best_i, best_c = 0, -1
+    for i in 1:num_sites(lat)
+        sublattice(lat, i) == b || continue
+        c = length(neighbor_bonds(lat, i))
+        c > best_c && ((best_i, best_c) = (i, c))
+    end
+    vecs = Set(round.(nb.vector; digits=6) for nb in neighbor_bonds(lat, best_i))
+    return vecs, best_c
+end
+
+# Same displacement set, but reconstructed purely from the motif via the
+# lazy accessors on the infinite lattice.
+function _motif_neighbor_vecs(Topo, b)
+    inf = InfiniteLattice(Topo)
+    p_b = basis_position(inf, b)
+    ib = incident_cell_bonds(inf, CellSite((0, 0), b))
+    vecs = Set(
+        round.(cell_position(inf, CellSite(Tuple(cb.offset), cb.dst)) .- p_b; digits=6) for
+        cb in ib
+    )
+    return vecs
+end
+
+@testset "finite Lattice motif interface — all topologies" begin
+    for Topo in _TC_TOPOS
+        lat = build_lattice(Topo, 4, 4)
+        uc = get_unit_cell(Topo)
+        nsub = num_sublattices(lat)
+
+        @test translation_vectors(lat) == basis_vectors(lat)
+        @test num_basis_sites(lat) == nsub
+        @test collect(site_orbits(lat)) == collect(1:nsub)
+        @test length(collect(cell_bonds(lat))) == length(uc.connections)
+
+        # basis_position matches the topology's sublattice offsets.
+        for b in 1:nsub
+            @test basis_position(lat, b) ≈ SVector{2,Float64}(uc.sublattice_positions[b])
+        end
+        @test_throws ArgumentError basis_position(lat, nsub + 1)
+    end
+end
+
+@testset "motif neighbours match the finite neighbor_bonds path" begin
+    # The strong independent check: the coordination shell reconstructed
+    # from the unit-cell motif must equal the one the established finite
+    # neighbour code produces for an interior site.
+    for Topo in _TC_TOPOS
+        for b in 1:num_sublattices(build_lattice(Topo, 2, 2))
+            finite_vecs, finite_c = _finite_neighbor_vecs(Topo, b)
+            motif_vecs = _motif_neighbor_vecs(Topo, b)
+            @test length(motif_vecs) == finite_c
+            @test motif_vecs == finite_vecs
+        end
+    end
+end
+
+@testset "InfiniteLattice — traits and undefined linear index" begin
+    for Topo in _TC_TOPOS
+        inf = InfiniteLattice(Topo)
+        @test size_trait(inf) == InfiniteSize()
+        @test !is_finite(inf)
+        @test periodicity(inf) == Periodic()
+
+        @test_throws DomainError num_sites(inf)
+        @test_throws DomainError position(inf, 1)
+        @test_throws DomainError neighbors(inf, 1)
+
+        fin = build_lattice(Topo, 3, 3)
+        @test collect(site_orbits(inf)) == collect(site_orbits(fin))
+        @test translation_vectors(inf) == basis_vectors(fin)
+        # Same motif as the finite lattice (src, dst, offset, type).
+        key(cb) = (cb.src, cb.dst, cb.offset, cb.type)
+        @test Set(key.(cell_bonds(inf))) == Set(key.(cell_bonds(fin)))
+    end
+end
+
+@testset "InfiniteLattice — materialize bridge and layout propagation" begin
+    inf = InfiniteLattice(Honeycomb)
+    fin = materialize(inf; dims=(4, 4))
+    @test fin isa Lattice
+    @test num_sites(fin) == 4 * 4 * 2      # honeycomb has 2 sublattices
+    @test is_finite(fin)
+    @test periodicity(fin) == Periodic()
+
+    # Custom layout flows through infinite → materialize → finite.
+    inf2 = InfiniteLattice(Square; layout=UniformLayout(XYSite()))
+    @test site_type(inf2, 1) == XYSite()
+    fin2 = materialize(inf2; dims=(2, 2))
+    @test site_type(fin2, 1) == XYSite()
+end
+
+@testset "InfiniteLattice — lazy access is translation invariant" begin
+    inf = InfiniteLattice(Kagome)
+    base = Set(
+        n.cell - c for n in neighbors_at(inf, CellSite((0, 0), 1)) for c in (SVector(0, 0),)
+    )
+    for cell in ((5, 5), (-3, 8), (100, -100))
+        shifted = Set(
+            n.cell - SVector(cell...) for n in neighbors_at(inf, CellSite(cell, 1))
+        )
+        @test shifted == base
+        # basis index of a neighbour is a valid sublattice id.
+        @test all(
+            1 <= n.basis <= num_basis_sites(inf) for
+            n in neighbors_at(inf, CellSite(cell, 1))
+        )
+    end
+end


### PR DESCRIPTION
Adds lazy, materialize-free thermodynamic-limit access to the whole 2D topology catalogue by implementing LatticeCore's translation-cell interface.

## What

The motif is read straight from each topology's `get_unit_cell` — no geometry is re-derived:
- `translation_vectors(::Lattice)` = `basis_vectors`
- `basis_position(::Lattice, b)` = the `b`-th `sublattice_positions` offset
- `cell_bonds(::Lattice)` = one `CellBond` per `UnitCell.Connection` (tagged `:type_N`, matching the instantiated `Bond`)
- `num_basis_sites` falls through to the existing `num_sublattices`

With those four, LatticeCore's generic `site_orbits` / `bond_orbits` / `cell_position` / `neighbors_at` / `incident_cell_bonds` work for **every** topology (Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack).

## InfiniteLattice

New `InfiniteLattice{Topo,T,L}` — the thermodynamic-limit counterpart of the finite `Lattice`, sharing the same `get_unit_cell` geometry. Reports `InfiniteSize`, throws on the linear-index API (`num_sites`/`position`/`neighbors`), and offers `materialize(inf; dims)` as an optional bridge to a periodic finite `Lattice` (propagating the layout). A TN builder written against the orbit accessors runs unchanged finite↔infinite.

## Tests (181 assertions)

- Motif interface for all 8 topologies.
- **Independent cross-check**: motif-reconstructed neighbour displacements equal the finite `neighbor_bonds` path for every sublattice of every topology.
- InfiniteLattice traits, `materialize` bridge + layout propagation, and translation invariance of the lazy coordination shell.

Validated locally against the dev LatticeCore (all green).

## ⚠️ Blocked on registration

Requires **LatticeCore 0.12.3** (the translation-cell interface, merged in LatticeCore#83). The General registry currently has only ≤0.12.2, so CI will stay red until LatticeCore 0.12.3 is registered. `[compat]` is set to `0.12.3` in anticipation. Merge after LatticeCore 0.12.3 lands in General.

🤖 Generated with [Claude Code](https://claude.com/claude-code)