### PR TITLE
feat: plaquette_orbits — complete site/bond/plaquette centring on the catalogue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lattice2D"
 uuid = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["souta shimozono"]
 
 [deps]
@@ -20,7 +20,7 @@ Lattice2DPlotsExt = "Plots"
 [compat]
 Aqua = "0.8"
 FFTW = "1"
-LatticeCore = "0.12.3"
+LatticeCore = "0.12.5"
 LinearAlgebra = "1.10"
 Plots = "1"
 Random = "1.10"

--- a/src/Lattice2D.jl
+++ b/src/Lattice2D.jl
@@ -113,6 +113,9 @@ import LatticeCore:
     cell_bonds,
     site_orbits,
     bond_orbits,
+    plaquette_orbits,
+    element_orbits,
+    element_orbit_position,
     cell_position,
     incident_cell_bonds,
     neighbors_at
@@ -294,7 +297,8 @@ export materialize, require_finite
 export InfiniteLattice
 export CellSite, CellBond
 export translation_vectors, num_basis_sites, basis_position, cell_bonds
-export site_orbits, bond_orbits
+export site_orbits, bond_orbits, plaquette_orbits
+export element_orbits, element_orbit_position
 export cell_position, incident_cell_bonds, neighbors_at
 
 end # module Lattice2D

--- a/src/core/translation_cell.jl
+++ b/src/core/translation_cell.jl
@@ -59,6 +59,16 @@ end
 
 LatticeCore.cell_bonds(::Lattice{Topo}) where {Topo} = _cell_bonds_from_unitcell(Topo)
 
+# The unit cell's plaquette rules are the plaquette-orbit representatives.
+# `element_orbits(lat, PlaquetteCenter())` and `element_orbit_position`
+# (both generic in LatticeCore) then work off these, completing the
+# site / bond / plaquette centring on the fundamental domain.
+function _plaquette_orbits(::Type{Topo}) where {Topo<:AbstractTopology{2}}
+    return Tuple(get_unit_cell(Topo).plaquettes)
+end
+
+LatticeCore.plaquette_orbits(::Lattice{Topo}) where {Topo} = _plaquette_orbits(Topo)
+
 # ---- InfiniteLattice: the thermodynamic-limit object ----------------
 
 """
@@ -130,6 +140,8 @@ end
 function LatticeCore.cell_bonds(::InfiniteLattice{Topo}) where {Topo}
     return _cell_bonds_from_unitcell(Topo)
 end
+
+LatticeCore.plaquette_orbits(::InfiniteLattice{Topo}) where {Topo} = _plaquette_orbits(Topo)
 
 # ---- Size / traits --------------------------------------------------
 

--- a/test/lattices/test_plaquette_orbits.jl
+++ b/test/lattices/test_plaquette_orbits.jl
@@ -1,0 +1,65 @@
+using Lattice2D
+using StaticArrays
+using Test
+
+const _PO_TOPOS = (
+    Square, Triangular, Honeycomb, Kagome, Lieb, ShastrySutherland, Dice, UnionJack
+)
+
+@testset "plaquette_orbits reproduce the unit cell's plaquette rules" begin
+    for Topo in _PO_TOPOS
+        rules = get_unit_cell(Topo).plaquettes
+        fin = build_lattice(Topo, 4, 4)
+        inf = InfiniteLattice(Topo)
+
+        for lat in (fin, inf)
+            po = collect(plaquette_orbits(lat))
+            @test length(po) == length(rules)
+            @test [(p.corners, p.type) for p in po] == [(r.corners, r.type) for r in rules]
+            # Routed through the centring trait too (compared by value —
+            # PlaquetteRule has no value `==`).
+            eo = collect(element_orbits(lat, PlaquetteCenter()))
+            @test [(p.corners, p.type) for p in eo] == [(p.corners, p.type) for p in po]
+        end
+    end
+end
+
+@testset "plaquette-centre position is the centroid of its corners" begin
+    for Topo in _PO_TOPOS
+        inf = InfiniteLattice(Topo)
+        for pr in plaquette_orbits(inf)
+            # Independent reconstruction of the centroid from the corner
+            # (sublattice, dx, dy) specs via cell_position.
+            corners = [cell_position(inf, (dx, dy), sub) for (sub, dx, dy) in pr.corners]
+            expected = sum(corners) / length(corners)
+            @test element_orbit_position(inf, PlaquetteCenter(), pr) ≈ expected
+        end
+    end
+    # Concrete value: the square plaquette is centred at (0.5, 0.5).
+    sq = only(plaquette_orbits(InfiniteLattice(Square)))
+    @test element_orbit_position(InfiniteLattice(Square), PlaquetteCenter(), sq) ≈
+        SVector(0.5, 0.5)
+end
+
+@testset "finite and infinite agree on the plaquette centring" begin
+    for Topo in _PO_TOPOS
+        fin = build_lattice(Topo, 4, 4)
+        inf = InfiniteLattice(Topo)
+        pf = collect(plaquette_orbits(fin))
+        pi = collect(plaquette_orbits(inf))
+        @test [(p.corners, p.type) for p in pf] == [(p.corners, p.type) for p in pi]
+        for (a, b) in zip(pf, pi)
+            @test element_orbit_position(fin, PlaquetteCenter(), a) ≈
+                element_orbit_position(inf, PlaquetteCenter(), b)
+        end
+    end
+end
+
+@testset "all three centrings are reachable on the infinite lattice" begin
+    inf = InfiniteLattice(Kagome)
+    @test length(collect(element_orbits(inf, VertexCenter()))) == 3      # sublattices
+    @test length(collect(element_orbits(inf, BondCenter()))) ==
+        length(get_unit_cell(Kagome).connections)
+    @test length(collect(element_orbits(inf, PlaquetteCenter()))) ==
+        length(get_unit_cell(Kagome).plaquettes)
+end


### PR DESCRIPTION
Completes the orbit-level element-centring on the 2D catalogue.

LatticeCore 0.12.5 added `element_orbits` / `element_orbit_position` / `plaquette_orbits`. Vertex and Bond centring already flowed through it via the motif (`site_orbits` / `bond_orbits`); this adds the missing **Plaquette** centring by returning each topology's `get_unit_cell(Topo).plaquettes` as the plaquette-orbit representatives, on both the finite `Lattice` and the `InfiniteLattice`.

With that, all 8 topologies expose **site / bond / plaquette** centring on the fundamental domain — reachable on the infinite lattice, where the enumeration API (`elements`/`element_position`) throws. `element_orbit_position(_, PlaquetteCenter(), rule)` gives the corner centroid for free (generic in LatticeCore).

## Tests (98 assertions)

- `plaquette_orbits` reproduces each unit cell's plaquette rules (finite and infinite).
- **Independent check**: the plaquette-centre position equals a from-scratch corner-centroid reconstruction (e.g. the square plaquette at `(0.5, 0.5)`).
- Finite and infinite agree.
- All three centrings are reachable on the infinite lattice.

Validated locally against dev LatticeCore 0.12.5.

## ⚠️ Blocked on registration

Requires **LatticeCore 0.12.5** (the orbit-element API, merged in LatticeCore#85). The General registry currently has ≤0.12.4, so CI stays red until 0.12.5 registers. `[compat]` set to `0.12.5` in anticipation; version 0.5.1 → 0.5.2.

Note: `PlaquetteRule` has no value `==` (Vector field), so equality is by `(corners, type)` — a minor LatticeCore papercut worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)